### PR TITLE
SPE-84: Use `PUT` method to send results instead of `POST`

### DIFF
--- a/service/agent/backend/backend_client.py
+++ b/service/agent/backend/backend_client.py
@@ -41,7 +41,7 @@ class BackendClient:
             },
             cls=AgentSerializer,
         )
-        response = requests.post(
+        response = requests.put(
             results_url,
             data=result_str,
             headers={


### PR DESCRIPTION
The orchestrator was updated to use `PUT` (instead of `POST`) for the endpoint that receives results for a given operation.
This PR makes that change and updates some of the existing unit tests to check we're invoking the orchestrator endpoint