### PR TITLE
SPE-89: [SNA] Remove unused UDF functions

### DIFF
--- a/app/scripts/setup_procs.sql
+++ b/app/scripts/setup_procs.sql
@@ -43,19 +43,7 @@ BEGIN
       EXTERNAL_ACCESS_INTEGRATIONS=(reference('monte_carlo_external_access'))
       FROM spec='service/mcd_agent_spec.yaml';
 
-   -- UDF functions used from the Streamlit application
-   CREATE OR REPLACE FUNCTION core.fetch_metrics ()
-      RETURNS varchar
-      SERVICE=core.mcd_agent_service
-      ENDPOINT='mcd-agent-endpoint'
-      AS '/api/v1/test/metrics';
-
-   CREATE OR REPLACE FUNCTION core.health_check()
-      RETURNS varchar
-      SERVICE=core.mcd_agent_service
-      ENDPOINT='mcd-agent-endpoint'
-      AS '/api/v1/test/health';
-
+  -- UDF functions used from the Streamlit application
   CREATE OR REPLACE FUNCTION core.reachability_test()
       RETURNS varchar
       SERVICE=core.mcd_agent_service

--- a/service/agent/sna/queries_runner.py
+++ b/service/agent/sna/queries_runner.py
@@ -25,5 +25,7 @@ class QueriesRunner(QueueAsyncProcessor[SnowflakeQuery]):
         )
 
     def _handler_wrapper(self, query: SnowflakeQuery):
-        logger.info(f"Running operation: {query.operation_id}, query: {query.query}")
+        logger.info(
+            f"Running operation: {query.operation_id}, query: {query.query[:500]}"
+        )
         self._queries_handler(query)


### PR DESCRIPTION
- Removed two UDFs no longer used: `health_check` and `fetch_metrics`
- Truncated the query in log messages to `500` characters