### PR TITLE
Dockerfile security improvements

### DIFF
--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -11,13 +11,6 @@ RUN pip install -r requirements-build.txt
 
 FROM python:3.12-alpine3.20 AS base
 
-# update openssl
-RUN apk update && apk add --no-cache openssl~3.3
-
-# upgrade global libraries to fix CVEs
-RUN pip install --no-cache-dir --upgrade pip==24.2 && \
-    pip install --no-cache-dir --upgrade setuptools==75.1.0
-
 COPY --from=builder /opt/venv /opt/venv
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
@@ -26,7 +19,6 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY agent/ ./agent
-COPY tests/ ./tests
 
 ARG code_version="local"
 ARG build_number="0"
@@ -37,10 +29,29 @@ FROM base AS tests
 COPY requirements-dev.txt .
 RUN pip install --no-cache-dir -r requirements-dev.txt
 
+COPY tests/ ./tests
+
 ARG pytest_params="tests"
 ARG CACHEBUST=1
 RUN python -m pytest $pytest_params
 
-FROM base AS final
+FROM python:3.12-alpine3.20 AS final
+
+# update openssl
+RUN apk update && apk add --no-cache openssl~3.3
+
+# upgrade global libraries to fix CVEs
+RUN pip install --no-cache-dir --upgrade pip==24.2 && \
+    pip install --no-cache-dir --upgrade setuptools==75.1.0
+
+RUN adduser --disabled-password mcdagent
+
+COPY --from=base --chown=mcdagent /opt/venv /opt/venv
+COPY --from=base --chown=mcdagent /agent /agent
+
+USER mcdagent
+
+ENV VIRTUAL_ENV=/opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
 
 CMD ["gunicorn", "agent.main:app", "--bind", "0.0.0.0:8000"]


### PR DESCRIPTION
- Updated Dockerfile to use a non-root user
- Copy test files only for the `tests` stage
- Reduced command history by copying from `base` instead of deriving from it
  - Moved native libraries updates to `final` stage