### PR TITLE
SPE-95: [SNA] support per job type warehouses

### DIFF
--- a/service/agent/sna/config/config_keys.py
+++ b/service/agent/sna/config/config_keys.py
@@ -21,3 +21,9 @@ CONFIG_PRE_SIGNED_URL_RESPONSE_EXPIRATION_SECONDS = (
 CONFIG_IS_REMOTE_UPGRADABLE = "IS_REMOTE_UPGRADABLE"
 # interval to send ACK messages in seconds
 CONFIG_ACK_INTERVAL_SECONDS = "ACK_INTERVAL_SECONDS"
+# name of the warehouse to use to execute queries
+CONFIG_WAREHOUSE_NAME = "WAREHOUSE_NAME"
+# JSON string with job types configuration mapping job types to warehouses and configuring pool size
+CONFIG_JOB_TYPES = "JOB_TYPES"
+
+DEFAULT_WAREHOUSE_NAME = "MCD_AGENT_WH"

--- a/service/agent/sna/config/config_manager.py
+++ b/service/agent/sna/config/config_manager.py
@@ -7,6 +7,9 @@ class ConfigurationManager:
     def __init__(self, persistence: ConfigurationPersistence):
         self._persistence = persistence
 
+    def get_optional_str_value(self, key: str) -> Optional[str]:
+        return self._get_value(key)
+
     def get_str_value(self, key: str, default_value: str) -> str:
         return self._get_value(key) or default_value
 

--- a/service/agent/sna/operation_result.py
+++ b/service/agent/sna/operation_result.py
@@ -10,6 +10,7 @@ class OperationAttributes(DataClassJsonMixin):
     trace_id: str
     compress_response_file: bool
     response_size_limit_bytes: int
+    job_type: Optional[str] = None
 
 
 @dataclass

--- a/service/agent/sna/queries_service.py
+++ b/service/agent/sna/queries_service.py
@@ -254,13 +254,16 @@ class QueriesService:
 
     def _get_connection_pool(self, job_type: Optional[str]) -> Optional[QueuePool]:
         if self._connection_pools:
-            return (
-                self._connection_pools.get(
-                    job_type, self._connection_pools[_DEFAULT_CONNECTION_POOL_KEY]
-                )
-                if job_type
-                else self._connection_pools[_DEFAULT_CONNECTION_POOL_KEY]
-            )
+            connection_pool = self._connection_pools.get(job_type) if job_type else None
+            if connection_pool:
+                logger.info(f"Using custom connection pool for job type: {job_type}")
+                return connection_pool
+            else:
+                if job_type:
+                    logger.info(
+                        f"Using default connection pool for job type: {job_type}"
+                    )
+                return self._connection_pools[_DEFAULT_CONNECTION_POOL_KEY]
         return None
 
     def _create_job_types_connection_pools(self):

--- a/service/agent/sna/queries_service.py
+++ b/service/agent/sna/queries_service.py
@@ -1,7 +1,9 @@
 import logging
 from contextlib import closing
+from dataclasses import dataclass
 from typing import Dict, Any, Optional, Tuple, List
 
+from dataclasses_json import DataClassJsonMixin
 from snowflake.connector import (
     DatabaseError,
     ProgrammingError,
@@ -16,7 +18,11 @@ from agent.sna.config.config_keys import (
     CONFIG_CONNECTION_POOL_SIZE,
     CONFIG_USE_CONNECTION_POOL,
     CONFIG_USE_SYNC_QUERIES,
+    CONFIG_WAREHOUSE_NAME,
+    DEFAULT_WAREHOUSE_NAME,
+    CONFIG_JOB_TYPES,
 )
+from agent.sna.operation_result import OperationAttributes
 from agent.sna.sf_connection import create_connection
 from agent.sna.sf_queries import (
     QUERY_EXECUTE_QUERY_WITH_HELPER,
@@ -55,6 +61,20 @@ _PROGRAMMING_ERRORS = [
 # connections to be created if needed (they will be immediately closed after being used).
 _DEFAULT_CONNECTION_POOL_SIZE = 3
 
+_DEFAULT_CONNECTION_POOL_KEY = "default"
+
+
+@dataclass
+class JobTypeConfiguration(DataClassJsonMixin):
+    job_type: str
+    warehouse_name: str
+    pool_size: Optional[int] = None
+
+
+@dataclass
+class JobTypesConfiguration(DataClassJsonMixin):
+    job_types: List[JobTypeConfiguration]
+
 
 class QueriesService:
     """
@@ -72,18 +92,25 @@ class QueriesService:
             CONFIG_USE_SYNC_QUERIES, False
         )
 
-        self._connection_pool = (
-            self._create_connection_pool(
-                pool_size=self._config_manager.get_int_value(
-                    CONFIG_CONNECTION_POOL_SIZE, _DEFAULT_CONNECTION_POOL_SIZE
-                ),
-            )
+        self._connection_pools: Optional[Dict[str, QueuePool]] = (
+            {
+                _DEFAULT_CONNECTION_POOL_KEY: self._create_connection_pool(
+                    pool_size=self._config_manager.get_int_value(
+                        CONFIG_CONNECTION_POOL_SIZE, _DEFAULT_CONNECTION_POOL_SIZE
+                    ),
+                    warehouse_name=self._get_default_warehouse_name(),
+                )
+            }
             if self._config_manager.get_bool_value(CONFIG_USE_CONNECTION_POOL, True)
             else None
         )
+        if self._connection_pools:
+            self._create_job_types_connection_pools()
 
-    def result_for_query(self, query_id: str) -> Dict[str, Any]:
-        with self._connect() as conn:
+    def result_for_query(
+        self, query_id: str, operation_attrs: OperationAttributes
+    ) -> Dict[str, Any]:
+        with self._connect(operation_attrs.job_type) as conn:
             with conn.cursor() as cur:
                 conn.get_query_status_throw_if_error(query_id)
                 cur.get_results_from_sfqid(query_id)
@@ -134,13 +161,13 @@ class QueriesService:
         }
         return result
 
-    def _connect(self) -> SnowflakeConnection:
-        if self._connection_pool:
+    def _connect(self, job_type: Optional[str] = None) -> SnowflakeConnection:
+        if connection_pool := self._get_connection_pool(job_type):
             # connections returned by SQLAlchemy's pool doesn't support context manager protocol
             # so we wrap them with "closing" to support it
-            return closing(self._connection_pool.connect())  # type: ignore
+            return closing(connection_pool.connect())  # type: ignore
         else:
-            return create_connection()
+            return create_connection(self._get_default_warehouse_name())
 
     def run_query_async(self, query: str) -> Optional[str]:
         with self._connect() as conn:
@@ -152,7 +179,7 @@ class QueriesService:
         timeout = query.timeout or 850
         operation_id = query.operation_id
         sql_query = query.query
-        with self._connect() as conn:
+        with self._connect(query.operation_attrs.job_type) as conn:
             with conn.cursor() as cur:
                 if self._direct_sync_queries:
                     cur.execute(sql_query)
@@ -187,7 +214,7 @@ class QueriesService:
     @staticmethod
     def result_for_exception(ex: Exception) -> Dict:
         result: Dict[str, Any] = {
-            ATTRIBUTE_NAME_ERROR: str(ex),
+            ATTRIBUTE_NAME_ERROR: str(ex) or f"Unknown error: {type(ex).__name__}",
         }
         if isinstance(ex, DatabaseError):
             result[ATTRIBUTE_NAME_ERROR_ATTRS] = {
@@ -201,10 +228,19 @@ class QueriesService:
 
         return result
 
+    def _get_default_warehouse_name(self) -> str:
+        return self._config_manager.get_str_value(
+            CONFIG_WAREHOUSE_NAME, DEFAULT_WAREHOUSE_NAME
+        )
+
+    def _get_job_type_warehouse_name(self, job_type: str) -> Optional[str]:
+        config_key = f"{CONFIG_WAREHOUSE_NAME}_{job_type.upper()}"
+        return self._config_manager.get_optional_str_value(config_key)
+
     @staticmethod
-    def _create_connection_pool(pool_size: int) -> Optional[QueuePool]:
+    def _create_connection_pool(pool_size: int, warehouse_name: str) -> QueuePool:
         return QueuePool(
-            create_connection,  # type: ignore
+            lambda: create_connection(warehouse_name),  # type: ignore
             dialect=SnowflakeDialect(),
             pool_size=pool_size,
             max_overflow=-1,
@@ -215,3 +251,41 @@ class QueriesService:
             pre_ping=True,
             # test the connection before using it, it uses "SELECT 1" for Snowflake
         )
+
+    def _get_connection_pool(self, job_type: Optional[str]) -> Optional[QueuePool]:
+        if self._connection_pools:
+            return (
+                self._connection_pools.get(
+                    job_type, self._connection_pools[_DEFAULT_CONNECTION_POOL_KEY]
+                )
+                if job_type
+                else self._connection_pools[_DEFAULT_CONNECTION_POOL_KEY]
+            )
+        return None
+
+    def _create_job_types_connection_pools(self):
+        job_types_config_str = self._config_manager.get_optional_str_value(
+            CONFIG_JOB_TYPES
+        )
+        if not self._connection_pools or not job_types_config_str:
+            return
+        try:
+            job_types_config = JobTypesConfiguration.from_json(job_types_config_str)
+        except Exception as ex:
+            logger.error(f"Failed to parse Job types configuration: {ex}")
+            return
+
+        default_connection_pool_size = self._config_manager.get_int_value(
+            CONFIG_CONNECTION_POOL_SIZE, _DEFAULT_CONNECTION_POOL_SIZE
+        )
+        for job_type_config in job_types_config.job_types:
+            job_type = job_type_config.job_type
+            warehouse_name = job_type_config.warehouse_name
+            pool_size = job_type_config.pool_size or default_connection_pool_size
+            self._connection_pools[job_type] = self._create_connection_pool(
+                pool_size=pool_size,
+                warehouse_name=warehouse_name,
+            )
+            logger.info(
+                f"Created connection pool for job type: {job_type} with warehouse: {warehouse_name}, size: {pool_size}"
+            )

--- a/service/agent/sna/sf_connection.py
+++ b/service/agent/sna/sf_connection.py
@@ -3,25 +3,27 @@ from snowflake.connector import connect as snowflake_connect
 
 from agent.utils.utils import get_sf_login_token
 
-WAREHOUSE_NAME = "MCD_AGENT_WH"
 
-
-def create_connection():
+def create_connection(warehouse_name: str):
     if os.getenv("SNOWFLAKE_HOST"):  # running in a Snowpark container
         return snowflake_connect(
             host=os.getenv("SNOWFLAKE_HOST"),
             account=os.getenv("SNOWFLAKE_ACCOUNT"),
-            warehouse=WAREHOUSE_NAME,
+            warehouse=warehouse_name,
             token=get_sf_login_token(),
             authenticator="oauth",
             paramstyle="qmark",
         )
     else:  # running locally
-        return snowflake_connect(
-            account=os.getenv("SNOWFLAKE_ACCOUNT"),
-            warehouse=os.getenv("SNOWFLAKE_WAREHOUSE"),
-            paramstyle="qmark",
-            user=os.getenv("SNOWFLAKE_USER"),
-            private_key_file=os.getenv("SNOWFLAKE_PRIVATE_KEY_FILE"),
-            role=os.getenv("SNOWFLAKE_ROLE"),
-        )
+        try:
+            return snowflake_connect(
+                account=os.getenv("SNOWFLAKE_ACCOUNT"),
+                warehouse=warehouse_name,
+                paramstyle="qmark",
+                user=os.getenv("SNOWFLAKE_USER"),
+                private_key_file=os.getenv("SNOWFLAKE_PRIVATE_KEY_FILE"),
+                role=os.getenv("SNOWFLAKE_ROLE"),
+            )
+        except Exception as ex:
+            print(ex)
+            raise

--- a/service/agent/sna/sf_connection.py
+++ b/service/agent/sna/sf_connection.py
@@ -15,15 +15,11 @@ def create_connection(warehouse_name: str):
             paramstyle="qmark",
         )
     else:  # running locally
-        try:
-            return snowflake_connect(
-                account=os.getenv("SNOWFLAKE_ACCOUNT"),
-                warehouse=warehouse_name,
-                paramstyle="qmark",
-                user=os.getenv("SNOWFLAKE_USER"),
-                private_key_file=os.getenv("SNOWFLAKE_PRIVATE_KEY_FILE"),
-                role=os.getenv("SNOWFLAKE_ROLE"),
-            )
-        except Exception as ex:
-            print(ex)
-            raise
+        return snowflake_connect(
+            account=os.getenv("SNOWFLAKE_ACCOUNT"),
+            warehouse=warehouse_name,
+            paramstyle="qmark",
+            user=os.getenv("SNOWFLAKE_USER"),
+            private_key_file=os.getenv("SNOWFLAKE_PRIVATE_KEY_FILE"),
+            role=os.getenv("SNOWFLAKE_ROLE"),
+        )

--- a/service/agent/sna/sna_service.py
+++ b/service/agent/sna/sna_service.py
@@ -52,6 +52,7 @@ _ATTR_NAME_EVENTS = "events"
 _ATTR_NAME_PARAMETERS = "parameters"
 _ATTR_NAME_CONFIG = "config"
 _ATTR_NAME_ENV = "env"
+_ATTR_NAME_JOB_TYPE = "job_type"
 
 _ATTR_NAME_SIZE_EXCEEDED = "__mcd_size_exceeded__"
 
@@ -443,6 +444,7 @@ class SnaService:
                         _ATTR_NAME_RESPONSE_SIZE_LIMIT_BYTES,
                         _DEFAULT_RESPONSE_SIZE_LIMIT_BYTES,
                     ),
+                    job_type=operation.get(_ATTR_NAME_JOB_TYPE),
                     trace_id=operation.get(_ATTR_NAME_TRACE_ID) or str(uuid.uuid4()),
                 ),
             )
@@ -535,7 +537,7 @@ class SnaService:
         Invoked by results publisher to push results for a query
         """
         try:
-            result = self._queries_service.result_for_query(query_id)
+            result = self._queries_service.result_for_query(query_id, operation_attrs)
             self._push_backend_results(operation_id, result, operation_attrs)
         except Exception as ex:
             logger.error(f"Failed to push results for query: {query_id}, error: {ex}")

--- a/service/tests/test_multiple_warehouses.py
+++ b/service/tests/test_multiple_warehouses.py
@@ -1,0 +1,155 @@
+from contextlib import closing
+from typing import Optional, Tuple
+from unittest import TestCase
+from unittest.mock import create_autospec, patch, Mock, ANY, call
+
+from sqlalchemy import QueuePool
+
+from agent.events.ack_sender import AckSender
+from agent.events.base_receiver import BaseReceiver
+from agent.events.events_client import EventsClient
+from agent.events.heartbeat_checker import HeartbeatChecker
+from agent.sna.config.config_keys import CONFIG_USE_CONNECTION_POOL, CONFIG_JOB_TYPES
+from agent.sna.config.config_manager import ConfigurationManager
+from agent.sna.config.config_persistence import ConfigurationPersistence
+from agent.sna.operation_result import OperationAttributes
+from agent.sna.operations_runner import OperationsRunner
+from agent.sna.queries_runner import QueriesRunner
+from agent.sna.queries_service import (
+    QueriesService,
+    JobTypesConfiguration,
+    JobTypeConfiguration,
+)
+from agent.sna.results_publisher import ResultsPublisher
+from agent.sna.sf_query import SnowflakeQuery
+from agent.sna.sna_service import SnaService
+
+_QUERY_LOGS_JOB_TYPES_CONFIG = JobTypesConfiguration(
+    job_types=[
+        JobTypeConfiguration(
+            job_type="query_logs",
+            warehouse_name="QUERY_LOGS_WH",
+            pool_size=1,
+        ),
+        JobTypeConfiguration(
+            job_type="sql_query",
+            warehouse_name="SQL_QUERY_WH",
+            pool_size=2,
+        ),
+    ],
+)
+
+
+class MultiWarehouseTests(TestCase):
+    def setUp(self):
+        self._mock_queries_runner = create_autospec(QueriesRunner)
+        self._mock_ops_runner = create_autospec(OperationsRunner)
+        self._mock_results_publisher = create_autospec(ResultsPublisher)
+        self._ack_sender = create_autospec(AckSender)
+        self._config_persistence = create_autospec(ConfigurationPersistence)
+        self._config_manager = ConfigurationManager(
+            persistence=self._config_persistence
+        )
+        self._events_client = EventsClient(
+            receiver=create_autospec(BaseReceiver),
+            heartbeat_checker=create_autospec(HeartbeatChecker),
+        )
+
+    @patch.object(QueriesService, "_create_connection_pool")
+    def test_query_logs_query_execution(self, mock_create_connection_pool: Mock):
+        def get_config_value(key: str) -> Optional[str]:
+            if key == CONFIG_USE_CONNECTION_POOL:
+                return "true"
+            elif key == CONFIG_JOB_TYPES:
+                return _QUERY_LOGS_JOB_TYPES_CONFIG.to_json()
+            return None
+
+        self._config_persistence.get_value.side_effect = get_config_value
+
+        mock_default_pool, mock_default_cursor = self._create_mock_pool()
+        mock_ql_pool, mock_ql_cursor = self._create_mock_pool()
+        mock_sq_pool, mock_sq_cursor = self._create_mock_pool()
+
+        def create_connection_pool(pool_size: int, warehouse_name: str):
+            if warehouse_name == "QUERY_LOGS_WH":
+                return mock_ql_pool
+            elif warehouse_name == "SQL_QUERY_WH":
+                return mock_sq_pool
+            return mock_default_pool
+
+        mock_create_connection_pool.side_effect = create_connection_pool
+
+        queries_service = QueriesService(
+            config_manager=self._config_manager,
+        )
+        service = SnaService(
+            queries_runner=self._mock_queries_runner,
+            ops_runner=self._mock_ops_runner,
+            results_publisher=self._mock_results_publisher,
+            events_client=self._events_client,
+            ack_sender=self._ack_sender,
+            queries_service=queries_service,
+            config_manager=self._config_manager,
+        )
+        service.start()
+
+        mock_create_connection_pool.assert_has_calls(
+            [
+                call(pool_size=3, warehouse_name="MCD_AGENT_WH"),
+                call(pool_size=1, warehouse_name="QUERY_LOGS_WH"),
+                call(pool_size=2, warehouse_name="SQL_QUERY_WH"),
+            ]
+        )
+
+        # run a query logs query and confirm it executes the query in the query logs pool
+        self._run_job_type_query(
+            service, "SELECT * FROM table", "query_logs", mock_ql_cursor
+        )
+
+        # now run a metadata query and assert it uses the default pool
+        self._run_job_type_query(
+            service, "SELECT * FROM table", "metadata", mock_default_cursor
+        )
+
+        # now run a sql-query query and assert it uses the default pool
+        self._run_job_type_query(
+            service, "SELECT * FROM table", "sql_query", mock_sq_cursor
+        )
+
+        # now run a query with no job type and assert it uses the default pool
+        self._run_job_type_query(
+            service, "SELECT * FROM table", None, mock_default_cursor
+        )
+
+    @staticmethod
+    def _create_mock_pool() -> Tuple[Mock, Mock]:
+        mock_pool = create_autospec(QueuePool)
+        mock_cursor = Mock()
+        mock_cursor.__iter__ = Mock(return_value=iter([]))
+        mock_connection = Mock()
+        mock_connection.cursor.return_value = closing(mock_cursor)  # type: ignore
+        mock_pool.connect.return_value = mock_connection
+
+        return mock_pool, mock_cursor
+
+    def _run_job_type_query(
+        self, service: SnaService, query: str, job_type: Optional[str], cursor: Mock
+    ):
+        cursor.reset_mock()
+        service._run_query(
+            SnowflakeQuery(
+                operation_id="1234",
+                query=query,
+                timeout=ANY,
+                operation_attrs=OperationAttributes(
+                    operation_id="1234",
+                    trace_id="5432",
+                    compress_response_file=False,
+                    response_size_limit_bytes=100000,
+                    job_type=job_type,
+                ),
+            )
+        )
+
+        # assert the query was executed in the query logs pool
+        cursor.execute.assert_called_once_with("SELECT * FROM table")


### PR DESCRIPTION
- New configuration setting to change the default warehouse: `WAREHOUSE_NAME`
  - Please note the warehouse created when the app is installed (`MCD_AGENT_WH`) is still used to load the configuration 
- New configuration setting to specify the warehouse name to use for a given job type: `JOB_TYPES`, example value (the string representation of the following JSON):
  ```json
  {
    "job_types": [
      {
        "job_type": "query_logs",
        "pool_size": 2,
        "warehouse_name": "MC_QUERY_LOGS_WH"
      },
      {
        "job_type": "sql_query",
        "pool_size": 4,
        "warehouse_name": "MC_MONITORS_WH"
      }
    ]
  }
  ``` 
- A connection pool is now created for each job type specified in `JOB_TYPES`, using the specified pool size
- This PR assumes at some point the DC will start sending a `job_type` attribute in operations so we can use the right warehouse, when no job_type is specified, the default connection pool is used