### PR TITLE
SPE-104: [SNA] remove hardcoded references to `MCD_AGENT` db

### DIFF
--- a/app/README-app.md
+++ b/app/README-app.md
@@ -131,9 +131,10 @@ The only configuration required is the authentication credentials that will be u
 The docs found here demonstrates this process with screenshots and other details: https://docs.getmontecarlo.com/docs/sna-agent-deployment.
 
 ## Usage Snippets
+`<APP_NAME>` is the name of the application database (which matches the name of the application), for development environments this is `MCD_AGENT`.
 ### Restart the Service:
 ```sql
-CALL MCD_AGENT.APP_PUBLIC.RESTART_SERVICE();
+CALL <APP_NAME>.APP_PUBLIC.RESTART_SERVICE();
 ```
 
 ### Update the token
@@ -141,18 +142,18 @@ You can update the token from the Streamlit UI, using the "Update Token" button.
 
 If you want to use SQL you can run this query:
 ```sql
-CALL MCD_AGENT.APP_PUBLIC.UPDATE_TOKEN('KEY_ID', 'KEY_SECRET');
+CALL <APP_NAME>.APP_PUBLIC.UPDATE_TOKEN('KEY_ID', 'KEY_SECRET');
 ```
 In both cases you need to [restart the service](#restart-the-service) for the new token to be used:
 
 
 ### Update the warehouse size
 ```sql
-CALL MCD_AGENT.APP_PUBLIC.SETUP_APP(wh_size => 'small')
+CALL <APP_NAME>.APP_PUBLIC.SETUP_APP(wh_size => 'small')
 ```
 
 ### Get service logs
 ```sql
-CALL MCD_AGENT.APP_PUBLIC.SERVICE_LOGS(500);
+CALL <APP_NAME>.APP_PUBLIC.SERVICE_LOGS(500);
 ```
 

--- a/app/scripts/setup_procs.sql
+++ b/app/scripts/setup_procs.sql
@@ -128,8 +128,8 @@ LANGUAGE SQL
 AS
 $$
 BEGIN
-    ALTER SERVICE IF EXISTS core.mcd_agent_service SUSPEND;
-    ALTER SERVICE IF EXISTS core.mcd_agent_service RESUME;
+    ALTER SERVICE core.mcd_agent_service SUSPEND;
+    ALTER SERVICE core.mcd_agent_service RESUME;
     RETURN 'Service restarted';
 END;
 $$;
@@ -143,7 +143,6 @@ $$
 BEGIN
     LET json_value VARCHAR := TO_JSON({'mcd_id': :key_id, 'mcd_token': :key_secret});
     ALTER SECRET CORE.MCD_AGENT_TOKEN SET SECRET_STRING=:json_value;
-    CALL APP_PUBLIC.RESTART_SERVICE();
     RETURN 'Token updated';
 END;
 $$;

--- a/app/scripts/setup_procs.sql
+++ b/app/scripts/setup_procs.sql
@@ -128,8 +128,8 @@ LANGUAGE SQL
 AS
 $$
 BEGIN
-    ALTER SERVICE core.mcd_agent_service SUSPEND;
-    ALTER SERVICE core.mcd_agent_service RESUME;
+    ALTER SERVICE IF EXISTS core.mcd_agent_service SUSPEND;
+    ALTER SERVICE IF EXISTS core.mcd_agent_service RESUME;
     RETURN 'Service restarted';
 END;
 $$;
@@ -143,6 +143,7 @@ $$
 BEGIN
     LET json_value VARCHAR := TO_JSON({'mcd_id': :key_id, 'mcd_token': :key_secret});
     ALTER SECRET CORE.MCD_AGENT_TOKEN SET SECRET_STRING=:json_value;
+    CALL APP_PUBLIC.RESTART_SERVICE();
     RETURN 'Token updated';
 END;
 $$;

--- a/app/streamlit/streamlit_app.py
+++ b/app/streamlit/streamlit_app.py
@@ -39,7 +39,7 @@ def setup_connection():
 
     # set the secret
     session.sql(
-        f"ALTER SECRET MCD_AGENT.CORE.MCD_AGENT_TOKEN SET SECRET_STRING=?;",
+        f"ALTER SECRET CORE.MCD_AGENT_TOKEN SET SECRET_STRING=?;",
         params=[json.dumps(key_json)],
     ).collect()
 

--- a/service/agent/sna/config/db_config.py
+++ b/service/agent/sna/config/db_config.py
@@ -7,7 +7,7 @@ from agent.sna.config.config_persistence import ConfigurationPersistence
 from agent.sna.sf_connection import create_connection
 from agent.sna.sf_queries import QUERY_LOAD_CONFIG, QUERY_UPDATE_CONFIG
 
-_CONFIG_TABLE_NAME = os.getenv("CONFIG_TABLE_NAME", "MCD_AGENT.CONFIG.APP_CONFIG")
+_CONFIG_TABLE_NAME = os.getenv("CONFIG_TABLE_NAME", "CONFIG.APP_CONFIG")
 
 logger = logging.getLogger(__name__)
 

--- a/service/agent/sna/logs_service.py
+++ b/service/agent/sna/logs_service.py
@@ -9,7 +9,7 @@ class LogsService:
 
     def get_logs(self, limit: int) -> List[Dict[str, Any]]:
         logs, _ = self._queries_service.run_query_and_fetch_all(
-            "CALL mcd_agent.app_public.service_logs(?)", [limit]
+            "CALL APP_PUBLIC.SERVICE_LOGS(?)", [limit]
         )
         return self._parse_logs(logs)
 

--- a/service/agent/sna/sf_connection.py
+++ b/service/agent/sna/sf_connection.py
@@ -9,6 +9,7 @@ def create_connection(warehouse_name: str):
         return snowflake_connect(
             host=os.getenv("SNOWFLAKE_HOST"),
             account=os.getenv("SNOWFLAKE_ACCOUNT"),
+            database=os.getenv("SNOWFLAKE_DATABASE"),
             warehouse=warehouse_name,
             token=get_sf_login_token(),
             authenticator="oauth",

--- a/service/agent/sna/sf_queries.py
+++ b/service/agent/sna/sf_queries.py
@@ -7,12 +7,12 @@ WITH RUN_QUERY AS PROCEDURE(op_json VARCHAR, query STRING)
     BEGIN
         BEGIN
             ALTER SESSION SET STATEMENT_TIMEOUT_IN_SECONDS={timeout};
-            CALL mcd_agent.core.execute_helper_query(:query);
+            CALL core.execute_helper_query(:query);
             SELECT * FROM TABLE(RESULT_SCAN(:SQLID));
-            SELECT mcd_agent.core.query_completed(:op_json, :SQLID);
+            SELECT core.query_completed(:op_json, :SQLID);
         EXCEPTION
             WHEN OTHER THEN BEGIN
-                SELECT mcd_agent.core.query_failed(:op_json, :sqlcode, :sqlerrm, :sqlstate);
+                SELECT core.query_failed(:op_json, :sqlcode, :sqlerrm, :sqlstate);
             END;
         END;
     END;
@@ -22,7 +22,7 @@ CALL RUN_QUERY(?, ?);
 
 QUERY_SET_STATEMENT_TIMEOUT = "ALTER SESSION SET STATEMENT_TIMEOUT_IN_SECONDS={timeout}"
 
-QUERY_EXECUTE_QUERY_WITH_HELPER_SYNC = "CALL MCD_AGENT.CORE.EXECUTE_HELPER_QUERY(?)"
+QUERY_EXECUTE_QUERY_WITH_HELPER_SYNC = "CALL CORE.EXECUTE_HELPER_QUERY(?)"
 
 QUERY_LOAD_CONFIG = "SELECT key, value FROM {table}"
 
@@ -37,6 +37,6 @@ WHEN NOT MATCHED THEN INSERT (key, value) VALUES (?, ?)
 QUERY_RESTART_SERVICE = """
 BEGIN
     CALL SYSTEM$WAIT(5);
-    CALL MCD_AGENT.APP_PUBLIC.RESTART_SERVICE();
+    CALL APP_PUBLIC.RESTART_SERVICE();
 END;
 """

--- a/service/agent/storage/stage_reader_writer.py
+++ b/service/agent/storage/stage_reader_writer.py
@@ -32,9 +32,7 @@ class StageReaderWriter(BaseStorageClient):
         self._queries_service = queries_service
         self._stage_name = stage_name or os.getenv(
             CONFIG_STAGE_NAME,
-            config_manager.get_str_value(
-                CONFIG_STAGE_NAME, "mcd_agent.core.data_store"
-            ),
+            config_manager.get_str_value(CONFIG_STAGE_NAME, "CORE.DATA_STORE"),
         )
         self._local = local
 
@@ -176,7 +174,7 @@ class StageReaderWriter(BaseStorageClient):
             # for some reason, when running in the SNA, we need to request the pre-signed url
             # using a store procedure, the url we get directly using GET_PRESIGNED_URL doesn't work.
             data, _ = self._run_stage_query(
-                "CALL mcd_agent.core.execute_query(?)",
+                "CALL CORE.EXECUTE_QUERY(?)",
                 "pre_signed_url",
                 key,
                 [pre_signed_url_query],

--- a/service/tests/test_config_manager.py
+++ b/service/tests/test_config_manager.py
@@ -7,7 +7,7 @@ from agent.sna.config.config_persistence import ConfigurationPersistence
 from agent.sna.config.db_config import DbConfig
 
 _EXPECTED_UPDATE_QUERY = """
-MERGE INTO MCD_AGENT.CONFIG.APP_CONFIG C
+MERGE INTO CONFIG.APP_CONFIG C
 USING (SELECT ? AS key) S
 ON S.key=C.key 
 WHEN MATCHED THEN UPDATE SET value=? 
@@ -66,7 +66,7 @@ class ConfigManagerTests(TestCase):
 
         persistence = DbConfig()
         mock_cursor.execute.assert_called_once_with(
-            "SELECT key, value FROM MCD_AGENT.CONFIG.APP_CONFIG"
+            "SELECT key, value FROM CONFIG.APP_CONFIG"
         )
         self.assertIsNone(persistence.get_value("key"))
         self.assertEqual("value1", persistence.get_value("key1"))
@@ -77,6 +77,6 @@ class ConfigManagerTests(TestCase):
         mock_cursor.execute.assert_has_calls(
             [
                 call(_EXPECTED_UPDATE_QUERY, ("key", "value", "key", "value")),
-                call("SELECT key, value FROM MCD_AGENT.CONFIG.APP_CONFIG"),
+                call("SELECT key, value FROM CONFIG.APP_CONFIG"),
             ]
         )

--- a/service/tests/test_storage_service.py
+++ b/service/tests/test_storage_service.py
@@ -162,7 +162,7 @@ class StorageServiceTests(TestCase):
         self._queries_service.run_query_and_fetch_all.return_value = [[url]], []
 
         self._execute_storage_operation(_GENERATE_PRE_SIGNED_OPERATION)
-        expected_query = "CALL mcd_agent.core.execute_query(?)"
+        expected_query = "CALL CORE.EXECUTE_QUERY(?)"
         expected_query_param = (
             "CALL GET_PRESIGNED_URL(@test.test_stage, 'mcd/test/test.json', 300.0)"
         )


### PR DESCRIPTION
When deploying through the Snowflake Internal Marketplace we learned that the app gets deployed with a custom name (defined by the user) and we were assuming that name was always `MCD_AGENT` (the default name of the app).

This PR removes all hardcoded references to `MCD_AGENT.` prefixing database objects (tables, stored procedures, etc.) and updates the code used to open the Snowflake connection to use the `SNOWFLAKE_DATABASE` env var to set the application database as the default database in the connection.

All scenarios affected by these changes were tested on dev.