### PR TITLE
SP-108 [SNA] fix hardcoded warehouse name

### DIFF
--- a/service/agent/sna/config/config_keys.py
+++ b/service/agent/sna/config/config_keys.py
@@ -25,5 +25,3 @@ CONFIG_ACK_INTERVAL_SECONDS = "ACK_INTERVAL_SECONDS"
 CONFIG_WAREHOUSE_NAME = "WAREHOUSE_NAME"
 # JSON string with job types configuration mapping job types to warehouses and configuring pool size
 CONFIG_JOB_TYPES = "JOB_TYPES"
-
-DEFAULT_WAREHOUSE_NAME = "MCD_AGENT_WH"

--- a/service/agent/sna/config/db_config.py
+++ b/service/agent/sna/config/db_config.py
@@ -5,6 +5,7 @@ from typing import Optional, Dict
 from agent.sna.config.config_persistence import ConfigurationPersistence
 from agent.sna.sf_connection import create_connection
 from agent.sna.sf_queries import QUERY_LOAD_CONFIG, QUERY_UPDATE_CONFIG
+from agent.utils.utils import get_application_name
 
 _CONFIG_TABLE_NAME = os.getenv("CONFIG_TABLE_NAME", "CONFIG.APP_CONFIG")
 
@@ -44,6 +45,4 @@ class DbConfig(ConfigurationPersistence):
 
     @staticmethod
     def _get_config_warehouse_name() -> str:
-        db_name = os.getenv("SNOWFLAKE_DATABASE", "MCD_AGENT")
-        default_wh_name = f"{db_name}_WH"
-        return os.getenv("SNA_WAREHOUSE_NAME", default_wh_name)
+        return os.getenv("SNA_WAREHOUSE_NAME", f"{get_application_name()}_WH")

--- a/service/agent/sna/config/db_config.py
+++ b/service/agent/sna/config/db_config.py
@@ -2,7 +2,6 @@ import logging
 import os
 from typing import Optional, Dict
 
-from agent.sna.config.config_keys import DEFAULT_WAREHOUSE_NAME
 from agent.sna.config.config_persistence import ConfigurationPersistence
 from agent.sna.sf_connection import create_connection
 from agent.sna.sf_queries import QUERY_LOAD_CONFIG, QUERY_UPDATE_CONFIG
@@ -45,4 +44,6 @@ class DbConfig(ConfigurationPersistence):
 
     @staticmethod
     def _get_config_warehouse_name() -> str:
-        return os.getenv("SNA_WAREHOUSE_NAME", DEFAULT_WAREHOUSE_NAME)
+        db_name = os.getenv("SNOWFLAKE_DATABASE", "MCD_AGENT")
+        default_wh_name = f"{db_name}_WH"
+        return os.getenv("SNA_WAREHOUSE_NAME", default_wh_name)

--- a/service/agent/sna/metrics_service.py
+++ b/service/agent/sna/metrics_service.py
@@ -1,11 +1,12 @@
 import logging
+import os
 import socket
 from typing import List
 
 import requests
 from requests import HTTPError
 
-from agent.utils.utils import LOCAL
+from agent.utils.utils import LOCAL, get_application_name
 
 logger = logging.getLogger(__name__)
 
@@ -29,10 +30,12 @@ class SnowparkMetricsService:
         request metrics for each IP address from http://<IP_ADDRESS>:9001/metrics.
         """
 
-        discover_host_name = (
-            "discover.monitor.mcd_agent_compute_pool.snowflakecomputing.internal"
-        )
-        lookup_result = socket.getaddrinfo(discover_host_name, 80)
+        discover_host_name = f"discover.monitor.{get_application_name()}_compute_pool.snowflakecomputing.internal"
+        try:
+            lookup_result = socket.getaddrinfo(discover_host_name, 80)
+        except Exception as ex:
+            logger.error(f"Failed to resolve {discover_host_name}: {ex}")
+            return []
         addresses = set([addr[4][0] for addr in lookup_result])
 
         logger.info(f"{discover_host_name} resolves to: {addresses}")

--- a/service/agent/sna/queries_service.py
+++ b/service/agent/sna/queries_service.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from contextlib import closing
 from dataclasses import dataclass
 from typing import Dict, Any, Optional, Tuple, List
@@ -19,7 +20,6 @@ from agent.sna.config.config_keys import (
     CONFIG_USE_CONNECTION_POOL,
     CONFIG_USE_SYNC_QUERIES,
     CONFIG_WAREHOUSE_NAME,
-    DEFAULT_WAREHOUSE_NAME,
     CONFIG_JOB_TYPES,
 )
 from agent.sna.operation_result import OperationAttributes
@@ -229,13 +229,12 @@ class QueriesService:
         return result
 
     def _get_default_warehouse_name(self) -> str:
-        return self._config_manager.get_str_value(
-            CONFIG_WAREHOUSE_NAME, DEFAULT_WAREHOUSE_NAME
-        )
-
-    def _get_job_type_warehouse_name(self, job_type: str) -> Optional[str]:
-        config_key = f"{CONFIG_WAREHOUSE_NAME}_{job_type.upper()}"
-        return self._config_manager.get_optional_str_value(config_key)
+        wh_name = self._config_manager.get_optional_str_value(CONFIG_WAREHOUSE_NAME)
+        if not wh_name:
+            db_name = os.getenv("SNOWFLAKE_DATABASE", "MCD_AGENT")
+            wh_name = f"{db_name}_WH"
+        logger.info(f"Using warehouse: {wh_name}")
+        return wh_name
 
     @staticmethod
     def _create_connection_pool(pool_size: int, warehouse_name: str) -> QueuePool:

--- a/service/agent/sna/queries_service.py
+++ b/service/agent/sna/queries_service.py
@@ -36,7 +36,7 @@ from agent.utils.serde import (
     ATTRIBUTE_NAME_ERROR_ATTRS,
     ATTRIBUTE_NAME_ERROR_TYPE,
 )
-from agent.utils.utils import LOCAL
+from agent.utils.utils import LOCAL, get_application_name
 
 logger = logging.getLogger(__name__)
 
@@ -229,12 +229,9 @@ class QueriesService:
         return result
 
     def _get_default_warehouse_name(self) -> str:
-        wh_name = self._config_manager.get_optional_str_value(CONFIG_WAREHOUSE_NAME)
-        if not wh_name:
-            db_name = os.getenv("SNOWFLAKE_DATABASE", "MCD_AGENT")
-            wh_name = f"{db_name}_WH"
-        logger.info(f"Using warehouse: {wh_name}")
-        return wh_name
+        return self._config_manager.get_str_value(
+            CONFIG_WAREHOUSE_NAME, f"{get_application_name()}_WH"
+        )
 
     @staticmethod
     def _create_connection_pool(pool_size: int, warehouse_name: str) -> QueuePool:

--- a/service/agent/utils/utils.py
+++ b/service/agent/utils/utils.py
@@ -103,6 +103,12 @@ def health_information(trace_id: Optional[str] = None) -> Dict[str, Any]:
     return health_info
 
 
+def get_application_name():
+    # in Snowpark, the application name matches the current database name
+    # for local execution, we use MCD_AGENT
+    return os.getenv("SNOWFLAKE_DATABASE", "MCD_AGENT")
+
+
 def _env_dictionary() -> Dict:
     env: Dict[str, Optional[str]] = {
         "PYTHON_SYS_VERSION": sys.version,


### PR DESCRIPTION
Similar to the issue fixed by https://github.com/monte-carlo-data/sna-artemis-agent/pull/24 the application name is used for the warehouse and the compute pool.
This PR fixes the code that references both the warehouse or compute pool to use the application name