### PR TITLE
References to other setup scripts updated to be relative

### DIFF
--- a/app/scripts/setup_script.sql
+++ b/app/scripts/setup_script.sql
@@ -14,9 +14,9 @@ GRANT USAGE ON SCHEMA app_admin TO APPLICATION ROLE app_admin;
 CREATE OR ALTER VERSIONED SCHEMA app_public;
 GRANT USAGE ON SCHEMA app_public TO APPLICATION ROLE app_user;
 
-EXECUTE IMMEDIATE FROM '/scripts/setup_procs.sql';
-EXECUTE IMMEDIATE FROM '/scripts/setup_ui.sql';
-EXECUTE IMMEDIATE FROM '/scripts/setup_secrets.sql';
-EXECUTE IMMEDIATE FROM '/scripts/setup_stage.sql';
-EXECUTE IMMEDIATE FROM '/scripts/setup_config.sql';
+EXECUTE IMMEDIATE FROM 'setup_procs.sql';
+EXECUTE IMMEDIATE FROM 'setup_ui.sql';
+EXECUTE IMMEDIATE FROM 'setup_secrets.sql';
+EXECUTE IMMEDIATE FROM 'setup_stage.sql';
+EXECUTE IMMEDIATE FROM 'setup_config.sql';
 


### PR DESCRIPTION
We were getting the following error from the security scan:
```
File '/scripts/setup_procs.sql' cannot be found in the same stage as the setup script is located..
```
We have these lines in setup_script.sql:

```
EXECUTE IMMEDIATE FROM '/scripts/setup_procs.sql';
EXECUTE IMMEDIATE FROM '/scripts/setup_ui.sql';
EXECUTE IMMEDIATE FROM '/scripts/setup_secrets.sql';
EXECUTE IMMEDIATE FROM '/scripts/setup_stage.sql';
EXECUTE IMMEDIATE FROM '/scripts/setup_config.sql';
```

This PR updates them to use relative paths