### PR TITLE
SPE-112: truncate query in log message

### DIFF
--- a/service/agent/sna/queries_service.py
+++ b/service/agent/sna/queries_service.py
@@ -199,7 +199,7 @@ class QueriesService:
                     )
                     cur.execute_async(execute_query, [operation_json, sql_query])
                     logger.info(
-                        f"Async query executed: {operation_id} {sql_query}, id: {cur.sfqid}"
+                        f"Async query executed: {operation_id} {sql_query[:500]}, id: {cur.sfqid}"
                     )
                     return None
 


### PR DESCRIPTION
During the E2E testing we detected that with this log message we include the full query:
```
Async query executed: ...
```
This PR truncates that query to 500 chars as we do in other places