### PR TITLE
Update manifest files with build number instead of `latest`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,16 @@ commands:
             grep "host_ports" app/scripts/setup_procs.sql
             sed -i -e "s|<< pipeline.parameters.backend_placeholder_scheme >>://<< pipeline.parameters.backend_placeholder_host >>|${BACKEND_URL_SCHEME}://${BACKEND_URL_HOST}|g" service/agent/utils/utils.py
             grep -2 "BACKEND_SERVICE_URL" service/agent/utils/utils.py
+  replace-manifest-tag:
+    parameters:
+      code_version:
+        type: string
+    steps:
+      - run:
+          name: Replace Backend URL
+          command: |
+            sed -i -e "s|:latest|:<< parameters.code_version >>|g" app/manifest.yml
+            grep -2 "images:" app/manifest.yml
 
 jobs:
   run-linter:
@@ -104,6 +114,8 @@ jobs:
           use-docker-credentials-store: true
       - setup-snowflake-cli
       - replace-backend-url
+      - replace-manifest-tag:
+          code_version: << parameters.code_version >>
       - docker/build:
           step-name: Build service image
           path: service

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,12 +209,14 @@ workflows:
       - publish-snowflake-app:
           name: publish-snowflake-app-dev
           code_version: ${NEXT_VERSION}
+          pre-steps:
+            - checkout
+            - generate-version-number-dev
           context:
             - snowflake-app-dev
           requires:
             - run-test-docker
             - build-and-push-image-dev
-            - generate-version-number-dev
           filters:
             branches:
               only:
@@ -250,10 +252,12 @@ workflows:
       - publish-snowflake-app:
           name: publish-snowflake-app-prod
           code_version: ${VERSION_TAG}
+          pre-steps:
+            - checkout
+            - generate-version-number-prod
           requires:
             - run-test-docker
             - build-and-push-image-prod
-            - generate-version-number-prod
           context:
             - snowflake-app-prod
           filters: # run only for tags starting with v, don't run for branches

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ commands:
           name: Replace Service Spec Tag
           command: |
             sed -i -e "s|:latest|:<< parameters.code_version >>|g" service/mcd_agent_spec.yaml
-            grep -2 "images:" service/mcd_agent_spec.yaml          
+            grep "image:" service/mcd_agent_spec.yaml          
 
 jobs:
   run-linter:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,6 +202,7 @@ workflows:
             - snowflake-app-dev
           requires:
             - run-test-docker
+            - run-linter
           filters:
             branches:
               only:
@@ -244,6 +245,7 @@ workflows:
             - snowflake-app-prod
           requires:
             - run-test-docker
+            - run-linter
           filters: # run only for tags starting with v, don't run for branches
             tags:
               only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,6 +168,8 @@ jobs:
       - checkout
       - setup-snowflake-cli
       - replace-backend-url
+      - replace-manifest-tag:
+          code_version: << parameters.code_version >>
       - run:
           name: Publish Snowflake app
           command: |
@@ -203,6 +205,7 @@ workflows:
                 - dev
       - publish-snowflake-app:
           name: publish-snowflake-app-dev
+          code_version: ${NEXT_VERSION}
           context:
             - snowflake-app-dev
           requires:
@@ -242,6 +245,7 @@ workflows:
               ignore: /.*/
       - publish-snowflake-app:
           name: publish-snowflake-app-prod
+          code_version: ${VERSION_TAG}
           requires:
             - run-test-docker
             - build-and-push-image-prod

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ commands:
             grep "host_ports" app/scripts/setup_procs.sql
             sed -i -e "s|<< pipeline.parameters.backend_placeholder_scheme >>://<< pipeline.parameters.backend_placeholder_host >>|${BACKEND_URL_SCHEME}://${BACKEND_URL_HOST}|g" service/agent/utils/utils.py
             grep -2 "BACKEND_SERVICE_URL" service/agent/utils/utils.py
-  replace-manifest-tag:
+  replace-image-references:
     parameters:
       code_version:
         type: string
@@ -78,6 +78,11 @@ commands:
           command: |
             sed -i -e "s|:latest|:<< parameters.code_version >>|g" app/manifest.yml
             grep -2 "images:" app/manifest.yml
+      - run:
+          name: Replace Service Spec Tag
+          command: |
+            sed -i -e "s|:latest|:<< parameters.code_version >>|g" service/mcd_agent_spec.yaml
+            grep -2 "images:" service/mcd_agent_spec.yaml          
 
 jobs:
   run-linter:
@@ -114,6 +119,8 @@ jobs:
           use-docker-credentials-store: true
       - setup-snowflake-cli
       - replace-backend-url
+      - replace-image-references:
+          code_version: << parameters.code_version >>
       - docker/build:
           step-name: Build service image
           path: service
@@ -169,7 +176,7 @@ jobs:
       - checkout
       - setup-snowflake-cli
       - replace-backend-url
-      - replace-manifest-tag:
+      - replace-image-references:
           code_version: << parameters.code_version >>
       - run:
           name: Publish Snowflake app

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,8 +114,6 @@ jobs:
           use-docker-credentials-store: true
       - setup-snowflake-cli
       - replace-backend-url
-      - replace-manifest-tag:
-          code_version: << parameters.code_version >>
       - docker/build:
           step-name: Build service image
           path: service

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ commands:
         type: string
     steps:
       - run:
-          name: Replace Backend URL
+          name: Replace Manifest Tag
           command: |
             sed -i -e "s|:latest|:<< parameters.code_version >>|g" app/manifest.yml
             grep -2 "images:" app/manifest.yml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,7 +221,6 @@ workflows:
           context:
             - snowflake-app-dev
           requires:
-            - run-test-docker
             - build-and-push-image-dev
           filters:
             branches:
@@ -263,7 +262,6 @@ workflows:
             - checkout
             - generate-version-number-prod
           requires:
-            - run-test-docker
             - build-and-push-image-prod
           context:
             - snowflake-app-prod

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,6 +164,9 @@ jobs:
   publish-snowflake-app:
     machine:
       image: ubuntu-2204:current
+    parameters:
+      code_version:
+        type: string
     steps:
       - checkout
       - setup-snowflake-cli

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,6 +214,7 @@ workflows:
           requires:
             - run-test-docker
             - build-and-push-image-dev
+            - generate-version-number-dev
           filters:
             branches:
               only:
@@ -252,6 +253,7 @@ workflows:
           requires:
             - run-test-docker
             - build-and-push-image-prod
+            - generate-version-number-prod
           context:
             - snowflake-app-prod
           filters: # run only for tags starting with v, don't run for branches


### PR DESCRIPTION
We're having issues updating the app in production, we're getting an error that is failing to pull the image and I think it might be related to the fact that we're using `latest` instead of the actual version we're releasing in the manifest files and I think that's confusing Snowflake.

This PR replaces `latest` in two manifest files with the version number we're releasing and adds a dependency to `run-linter` so we don't publish images if there's a linter error