### PR TITLE
Add Snowflake App version initializer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,16 +143,6 @@ jobs:
             docker tag montecarlodata/<< parameters.docker_hub_repository >>:latest $SNOWFLAKE_REPO_URL/mcd_agent:latest
             docker push $SNOWFLAKE_REPO_URL/mcd_agent:latest
 
-  restart-snowflake-service:
-    machine:
-      image: ubuntu-2204:current
-    steps:
-      - setup-snowflake-cli
-      - run:
-          name: Restart Snowflake service
-          command: |
-            snow sql --query "CALL MCD_AGENT.APP_PUBLIC.RESTART_SERVICE()" --temporary-connection
-
   run-test-docker:
     machine:
       image: ubuntu-2204:current
@@ -226,17 +216,6 @@ workflows:
             branches:
               only:
                 - dev
-#      - restart-snowflake-service:
-#          name: restart-snowflake-service-dev
-#          context:
-#            - snowflake-app-dev
-#          requires:
-#            - build-and-push-image-dev
-#            - publish-snowflake-app-dev
-#          filters:
-#            branches:
-#              only:
-#                - dev
       - build-and-push-image:
           name: build-and-push-image-prod
           docker_hub_repository: sna-agent

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -226,17 +226,17 @@ workflows:
             branches:
               only:
                 - dev
-      - restart-snowflake-service:
-          name: restart-snowflake-service-dev
-          context:
-            - snowflake-app-dev
-          requires:
-            - build-and-push-image-dev
-            - publish-snowflake-app-dev
-          filters:
-            branches:
-              only:
-                - dev
+#      - restart-snowflake-service:
+#          name: restart-snowflake-service-dev
+#          context:
+#            - snowflake-app-dev
+#          requires:
+#            - build-and-push-image-dev
+#            - publish-snowflake-app-dev
+#          filters:
+#            branches:
+#              only:
+#                - dev
       - build-and-push-image:
           name: build-and-push-image-prod
           docker_hub_repository: sna-agent

--- a/app/manifest.yml
+++ b/app/manifest.yml
@@ -31,3 +31,6 @@ references:
         - USAGE
       object_type: PROCEDURE
       register_callback: app_admin.register_single_reference
+
+lifecycle_callback:
+  version_initializer: core.version_init

--- a/app/manifest.yml
+++ b/app/manifest.yml
@@ -32,5 +32,5 @@ references:
       object_type: PROCEDURE
       register_callback: app_admin.register_single_reference
 
-lifecycle_callback:
+lifecycle_callbacks:
   version_initializer: core.version_init

--- a/app/scripts/setup_procs.sql
+++ b/app/scripts/setup_procs.sql
@@ -69,6 +69,16 @@ END;
 $$;
 GRANT USAGE ON PROCEDURE app_public.setup_app(INT, INT, VARCHAR, VARCHAR, INT) TO APPLICATION ROLE app_admin;
 
+CREATE OR REPLACE PROCEDURE core.version_init()
+LANGUAGE SQL
+AS
+$$
+BEGIN
+    ALTER SERVICE IF EXISTS core.mcd_agent_service FROM spec='service/mcd_agent_spec.yaml';
+END;
+$$;
+
+
 -- Stored procedure used to run queries using the reference defined in the manifest file,
 -- which uses the stored procedure defined in MCD_APP_HELPER.
 CREATE OR REPLACE PROCEDURE core.execute_helper_query(query STRING)

--- a/app/scripts/setup_procs.sql
+++ b/app/scripts/setup_procs.sql
@@ -70,11 +70,13 @@ $$;
 GRANT USAGE ON PROCEDURE app_public.setup_app(INT, INT, VARCHAR, VARCHAR, INT) TO APPLICATION ROLE app_admin;
 
 CREATE OR REPLACE PROCEDURE core.version_init()
+RETURNS STRING
 LANGUAGE SQL
 AS
 $$
 BEGIN
     ALTER SERVICE IF EXISTS core.mcd_agent_service FROM spec='service/mcd_agent_spec.yaml';
+    RETURN 'Done';
 END;
 $$;
 


### PR DESCRIPTION
What's new:
- Adds a "version initializer" stored procedure to the app, as documented [here](https://docs.snowflake.com/en/developer-guide/native-apps/update-app-develop#add-the-version-initializer-to-an-app), this allows us to automatically update the Docker image for the service when the application is updated, without this change the user needs to call `setup_app` for the upgrade to complete. 
- Removes the steps from the CircleCI build that were restarting the service for the dev environment, as that's no longer needed now that we're using the right way to upgrade it.