### PR TITLE
VULN-492: Upgraded jinja2 from 3.1.4 to 3.15

### DIFF
--- a/service/requirements.in
+++ b/service/requirements.in
@@ -3,6 +3,7 @@ dataclasses-json==0.6.7
 flask==3.0.3
 flask-sse==1.0.0
 gunicorn==23.0.0
+jinja2==3.1.5
 retry2==0.9.5
 snowflake-sqlalchemy==1.6.1
 sseclient==0.0.27

--- a/service/requirements.txt
+++ b/service/requirements.txt
@@ -8,7 +8,7 @@ asn1crypto==1.5.1
     # via
     #   -c requirements-build.txt
     #   snowflake-connector-python
-blinker==1.8.2
+blinker==1.9.0
     # via flask
 certifi==2024.8.30
     # via
@@ -55,8 +55,10 @@ idna==3.10
     #   snowflake-connector-python
 itsdangerous==2.2.0
     # via flask
-jinja2==3.1.4
-    # via flask
+jinja2==3.1.5
+    # via
+    #   -r requirements.in
+    #   flask
 markupsafe==3.0.2
     # via
     #   jinja2


### PR DESCRIPTION
Added jinja2 to requirements.in because we need to upgrade to jinja2 version 3.1.5 to fix the vulnerability issue. As it was used by flask I first tried to upgrade flask to the latest version (3.1.0) but that version still uses jinja2 version 3.1.4 so I ended up adding the reference directly.