### PR TITLE
Push logs from SNA agent periodically

### DIFF
--- a/app/scripts/setup_procs.sql
+++ b/app/scripts/setup_procs.sql
@@ -203,7 +203,7 @@ AS $$
                 RETURN '{
                     "type": "CONFIGURATION",
                     "payload":{
-                      "host_ports": ["artemis.dev.getmontecarlo.com:443"]
+                      "host_ports": ["artemis.getmontecarlo.com:443"]
                     }
                 }';
         END CASE;

--- a/app/scripts/setup_procs.sql
+++ b/app/scripts/setup_procs.sql
@@ -203,7 +203,7 @@ AS $$
                 RETURN '{
                     "type": "CONFIGURATION",
                     "payload":{
-                      "host_ports": ["artemis.getmontecarlo.com:443"]
+                      "host_ports": ["artemis.dev.getmontecarlo.com:443"]
                     }
                 }';
         END CASE;

--- a/service/agent/events/heartbeat_checker.py
+++ b/service/agent/events/heartbeat_checker.py
@@ -49,7 +49,7 @@ class HeartbeatChecker:
         return self._current_loop_id == loop_id
 
     def _run_heartbeat_checker(self, loop_id: str):
-        logger.info("Heartbeat monitor started")
+        logger.info("Heartbeat monitor started %s", loop_id)
         while self._is_current_loop(loop_id):
             with self._condition:
                 self._condition.wait(timeout=self._inactivity_timeout_seconds / 2)
@@ -57,6 +57,6 @@ class HeartbeatChecker:
             if not self._is_current_loop(loop_id):
                 break
             if elapsed_time.total_seconds() > self._inactivity_timeout_seconds:
-                logger.error("Heartbeat timeout")
+                logger.error("Heartbeat timeout %s", loop_id)
                 self._handler()
-        logger.info("Heartbeat monitor stopped")
+        logger.info("Heartbeat monitor stopped, %s", loop_id)

--- a/service/agent/sna/config/config_keys.py
+++ b/service/agent/sna/config/config_keys.py
@@ -21,6 +21,8 @@ CONFIG_PRE_SIGNED_URL_RESPONSE_EXPIRATION_SECONDS = (
 CONFIG_IS_REMOTE_UPGRADABLE = "IS_REMOTE_UPGRADABLE"
 # interval to send ACK messages in seconds
 CONFIG_ACK_INTERVAL_SECONDS = "ACK_INTERVAL_SECONDS"
+# interval to push logs in seconds
+CONFIG_PUSH_LOGS_INTERVAL_SECONDS = "PUSH_LOGS_INTERVAL_SECONDS"
 # name of the warehouse to use to execute queries
 CONFIG_WAREHOUSE_NAME = "WAREHOUSE_NAME"
 # JSON string with job types configuration mapping job types to warehouses and configuring pool size

--- a/service/agent/sna/logs_service.py
+++ b/service/agent/sna/logs_service.py
@@ -1,6 +1,8 @@
+from datetime import datetime, timezone
 from typing import List, Dict, Any, Tuple
 
 from agent.sna.queries_service import QueriesService
+from agent.utils.utils import LOCAL
 
 
 class LogsService:
@@ -8,6 +10,14 @@ class LogsService:
         self._queries_service = queries_service
 
     def get_logs(self, limit: int) -> List[Dict[str, Any]]:
+        if LOCAL:
+            # In local mode, we don't have access to the database, so we return a dummy record
+            return [
+                {
+                    "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+                    "message": "This is a dummy log message.",
+                }
+            ]
         logs, _ = self._queries_service.run_query_and_fetch_all(
             "CALL APP_PUBLIC.SERVICE_LOGS(?)", [limit]
         )

--- a/service/agent/sna/metrics_service.py
+++ b/service/agent/sna/metrics_service.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import socket
 from typing import List
 

--- a/service/agent/sna/queries_runner.py
+++ b/service/agent/sna/queries_runner.py
@@ -3,6 +3,7 @@ from typing import Callable
 
 from agent.sna.sf_query import SnowflakeQuery
 from agent.utils.queue_async_processor import QueueAsyncProcessor
+from agent.utils.utils import get_query_for_logs
 
 logger = logging.getLogger(__name__)
 
@@ -26,6 +27,6 @@ class QueriesRunner(QueueAsyncProcessor[SnowflakeQuery]):
 
     def _handler_wrapper(self, query: SnowflakeQuery):
         logger.info(
-            f"Running operation: {query.operation_id}, query: {query.query[:500]}"
+            f"Running operation: {query.operation_id}, query: {get_query_for_logs(query.query)}"
         )
         self._queries_handler(query)

--- a/service/agent/sna/queries_service.py
+++ b/service/agent/sna/queries_service.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from contextlib import closing
 from dataclasses import dataclass
 from typing import Dict, Any, Optional, Tuple, List
@@ -36,7 +35,7 @@ from agent.utils.serde import (
     ATTRIBUTE_NAME_ERROR_ATTRS,
     ATTRIBUTE_NAME_ERROR_TYPE,
 )
-from agent.utils.utils import LOCAL, get_application_name
+from agent.utils.utils import LOCAL, get_application_name, get_query_for_logs
 
 logger = logging.getLogger(__name__)
 
@@ -199,7 +198,7 @@ class QueriesService:
                     )
                     cur.execute_async(execute_query, [operation_json, sql_query])
                     logger.info(
-                        f"Async query executed: {operation_id} {sql_query[:500]}, id: {cur.sfqid}"
+                        f"Async query executed: {operation_id} {get_query_for_logs(sql_query)}, id: {cur.sfqid}"
                     )
                     return None
 

--- a/service/agent/sna/timer_service.py
+++ b/service/agent/sna/timer_service.py
@@ -1,0 +1,44 @@
+import logging
+from threading import Thread, Condition
+from typing import Optional, Callable
+
+logger = logging.getLogger(__name__)
+
+
+class TimerService:
+    def __init__(self, name: str, interval_seconds: int):
+        """
+        Invokes the handler passed in `start` every `interval_seconds` seconds
+        """
+        self._name = name
+        self._interval = interval_seconds
+        self._handler: Optional[Callable[[], None]] = None
+        self._condition = Condition()
+        self._running = False
+
+    def start(self, handler: Callable[[], None]):
+        self._handler = handler
+        self._running = True
+        th = Thread(target=self._run)
+        th.start()
+
+    def stop(self):
+        with self._condition:
+            self._running = False
+            self._condition.notify_all()
+
+    def _run(self):
+        logger.info("%s started", self._name)
+        while self._running:
+            with self._condition:
+                self._condition.wait(self._interval)
+            if not self._running:
+                break
+            if not self._handler:
+                logger.error("No handler defined for %s", self._name)
+                return
+            try:
+                self._handler()
+            except Exception as ex:
+                logger.exception("Failed to run %s operation: %s", self._name, ex)
+        logger.info("%s stopped", self._name)

--- a/service/agent/utils/utils.py
+++ b/service/agent/utils/utils.py
@@ -12,7 +12,7 @@ from agent.utils.settings import VERSION, BUILD_NUMBER
 
 BACKEND_SERVICE_URL = os.getenv(
     "BACKEND_SERVICE_URL",
-    "https://artemis.getmontecarlo.com:443",
+    "https://artemis.dev.getmontecarlo.com:443",
 )
 LOCAL = os.getenv("SNOWFLAKE_HOST") is None  # not running in Snowpark containers
 DEBUG = os.getenv("DEBUG", "false").lower() == "true"
@@ -46,6 +46,7 @@ def init_logging():
         stream=sys.stdout,
         level=logging.DEBUG if DEBUG else logging.INFO,
         format="[%(asctime)s] %(levelname)s:%(name)s: %(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%SZ",
     )
     logging.getLogger("snowflake.connector.cursor").setLevel(logging.WARNING)
 

--- a/service/agent/utils/utils.py
+++ b/service/agent/utils/utils.py
@@ -12,7 +12,7 @@ from agent.utils.settings import VERSION, BUILD_NUMBER
 
 BACKEND_SERVICE_URL = os.getenv(
     "BACKEND_SERVICE_URL",
-    "https://artemis.dev.getmontecarlo.com:443",
+    "https://artemis.getmontecarlo.com:443",
 )
 LOCAL = os.getenv("SNOWFLAKE_HOST") is None  # not running in Snowpark containers
 DEBUG = os.getenv("DEBUG", "false").lower() == "true"

--- a/service/agent/utils/utils.py
+++ b/service/agent/utils/utils.py
@@ -110,6 +110,10 @@ def get_application_name():
     return os.getenv("SNOWFLAKE_DATABASE", "MCD_AGENT")
 
 
+def get_query_for_logs(query: str) -> str:
+    return query[:500].replace("\n", " ")  # limit to 500 chars and remove new lines
+
+
 def _env_dictionary() -> Dict:
     env: Dict[str, Optional[str]] = {
         "PYTHON_SYS_VERSION": sys.version,

--- a/service/tests/test_app_service.py
+++ b/service/tests/test_app_service.py
@@ -17,6 +17,7 @@ from agent.sna.queries_service import QueriesService
 from agent.sna.results_publisher import ResultsPublisher
 from agent.sna.sf_query import SnowflakeQuery
 from agent.sna.sna_service import SnaService
+from agent.sna.timer_service import TimerService
 from agent.storage.storage_service import StorageService
 from agent.utils.serde import (
     ATTRIBUTE_NAME_ERROR,
@@ -60,6 +61,7 @@ class AppServiceTests(TestCase):
         self._config_manager = ConfigurationManager(
             persistence=self._config_persistence
         )
+        self._logs_sender = create_autospec(TimerService)
         self._service = SnaService(
             queries_runner=self._mock_queries_runner,
             ops_runner=self._mock_ops_runner,
@@ -68,6 +70,7 @@ class AppServiceTests(TestCase):
             ack_sender=self._ack_sender,
             queries_service=self._queries_service,
             config_manager=self._config_manager,
+            logs_sender=self._logs_sender,
         )
 
     def test_service_start_stop(self):
@@ -95,6 +98,7 @@ class AppServiceTests(TestCase):
             ack_sender=self._ack_sender,
             queries_service=self._queries_service,
             config_manager=self._config_manager,
+            logs_sender=self._logs_sender,
         )
         service.start()
         events_client._event_received(_QUERY_OPERATION)
@@ -187,6 +191,7 @@ class AppServiceTests(TestCase):
             queries_service=self._queries_service,
             config_manager=self._config_manager,
             storage_service=storage,
+            logs_sender=self._logs_sender,
         )
         service.start()
         query_operation = deepcopy(_QUERY_OPERATION)
@@ -288,6 +293,7 @@ class AppServiceTests(TestCase):
             ack_sender=self._ack_sender,
             queries_service=self._queries_service,
             config_manager=self._config_manager,
+            logs_sender=self._logs_sender,
         )
         service.start()
         events_client._event_received(_HEALTH_OPERATION)

--- a/service/tests/test_logs_service.py
+++ b/service/tests/test_logs_service.py
@@ -24,7 +24,6 @@ class LogsServiceTests(TestCase):
         )
 
         logs = self._service.get_logs(100)
-        print(logs)
         self.assertEqual(4, len(logs))
         self.assertEqual("2021-01-01 00:00:00", logs[0]["timestamp"])
         self.assertEqual("log line 1", logs[0]["message"])

--- a/service/tests/test_logs_service.py
+++ b/service/tests/test_logs_service.py
@@ -9,11 +9,14 @@ class LogsServiceTests(TestCase):
         self._queries_service = Mock()
         self._service = LogsService(queries_service=self._queries_service)
 
+    @patch("agent.sna.logs_service.LOCAL", False)
     def test_fetch_logs(self):
         self._queries_service.run_query_and_fetch_all.return_value = (
             [
                 ("[2021-01-01 00:00:00] log line 1",),
                 ("[2021-01-01 00:00:01] log line 2",),
+                ("no ts line",),
+                ("[2025-04-28 22:46:21 +0000] [7] [INFO] Booting worker with pid: 7",),
             ],
             [
                 ("log_line",),
@@ -21,8 +24,13 @@ class LogsServiceTests(TestCase):
         )
 
         logs = self._service.get_logs(100)
-        self.assertEqual(2, len(logs))
+        print(logs)
+        self.assertEqual(4, len(logs))
         self.assertEqual("2021-01-01 00:00:00", logs[0]["timestamp"])
         self.assertEqual("log line 1", logs[0]["message"])
         self.assertEqual("2021-01-01 00:00:01", logs[1]["timestamp"])
         self.assertEqual("log line 2", logs[1]["message"])
+        self.assertEqual("", logs[2]["timestamp"])
+        self.assertEqual("no ts line", logs[2]["message"])
+        self.assertEqual("2025-04-28 22:46:21 +0000", logs[3]["timestamp"])
+        self.assertEqual("[7] [INFO] Booting worker with pid: 7", logs[3]["message"])

--- a/service/tests/test_metrics_service.py
+++ b/service/tests/test_metrics_service.py
@@ -15,6 +15,7 @@ from agent.sna.operations_runner import OperationsRunner, Operation
 from agent.sna.queries_runner import QueriesRunner
 from agent.sna.results_publisher import ResultsPublisher
 from agent.sna.sna_service import SnaService
+from agent.sna.timer_service import TimerService
 
 _REQUEST_METRICS_OPERATION = {
     "type": "push_metrics",
@@ -38,6 +39,7 @@ class MetricsServiceTests(TestCase):
             events_client=self._events_client,
             config_manager=self._config_manager,
             ack_sender=create_autospec(AckSender),
+            logs_sender=create_autospec(TimerService),
         )
         self._service.start()
 

--- a/service/tests/test_multiple_warehouses.py
+++ b/service/tests/test_multiple_warehouses.py
@@ -23,6 +23,7 @@ from agent.sna.queries_service import (
 from agent.sna.results_publisher import ResultsPublisher
 from agent.sna.sf_query import SnowflakeQuery
 from agent.sna.sna_service import SnaService
+from agent.sna.timer_service import TimerService
 
 _QUERY_LOGS_JOB_TYPES_CONFIG = JobTypesConfiguration(
     job_types=[
@@ -46,6 +47,7 @@ class MultiWarehouseTests(TestCase):
         self._mock_ops_runner = create_autospec(OperationsRunner)
         self._mock_results_publisher = create_autospec(ResultsPublisher)
         self._ack_sender = create_autospec(AckSender)
+        self._logs_sender = create_autospec(TimerService)
         self._config_persistence = create_autospec(ConfigurationPersistence)
         self._config_manager = ConfigurationManager(
             persistence=self._config_persistence
@@ -90,6 +92,7 @@ class MultiWarehouseTests(TestCase):
             ack_sender=self._ack_sender,
             queries_service=queries_service,
             config_manager=self._config_manager,
+            logs_sender=self._logs_sender,
         )
         service.start()
 

--- a/service/tests/test_storage_service.py
+++ b/service/tests/test_storage_service.py
@@ -16,6 +16,7 @@ from agent.sna.queries_runner import QueriesRunner
 from agent.sna.queries_service import QueriesService
 from agent.sna.results_publisher import ResultsPublisher
 from agent.sna.sna_service import SnaService
+from agent.sna.timer_service import TimerService
 from agent.storage.stage_reader_writer import StageReaderWriter
 from agent.storage.storage_service import StorageService
 from agent.utils.serde import (
@@ -81,6 +82,7 @@ class StorageServiceTests(TestCase):
             config_manager=self._config_manager,
         )
         self._ack_sender = create_autospec(AckSender)
+        self._logs_sender = create_autospec(TimerService)
         self._service = SnaService(
             queries_runner=self._mock_queries_runner,
             ops_runner=self._mock_ops_runner,
@@ -90,6 +92,7 @@ class StorageServiceTests(TestCase):
             ack_sender=self._ack_sender,
             queries_service=self._queries_service,
             config_manager=self._config_manager,
+            logs_sender=self._logs_sender,
         )
         self._service.start()
 


### PR DESCRIPTION
- New background thread used to push logs to the server every 5 minutes
- Datetime format used for logs changed to be ISO compatible 
- New lines removed from logged queries to prevent generating multiple log messages from a single query