### PR TITLE
Preventing the operations runner from stopping when an operation fails

### DIFF
--- a/service/agent/utils/queue_async_processor.py
+++ b/service/agent/utils/queue_async_processor.py
@@ -1,6 +1,6 @@
 import logging
 from threading import Condition, Thread
-from typing import Callable, List, TypeVar, Generic
+from typing import Callable, List, TypeVar, Generic, Any
 
 logger = logging.getLogger(__name__)
 
@@ -54,5 +54,11 @@ class QueueAsyncProcessor(Generic[T]):
                 to_execute = self._queue.copy()
                 self._queue.clear()
             for o in to_execute:
-                self._handler(o)
+                self._invoke_handler(o)
         logger.info(f"{thread_name} stopped")
+
+    def _invoke_handler(self, param: Any):
+        try:
+            self._handler(param)
+        except Exception as ex:
+            logger.exception(f"Failed to run operation: {ex}")

--- a/service/tests/test_async_processor.py
+++ b/service/tests/test_async_processor.py
@@ -1,0 +1,30 @@
+from typing import Optional
+from unittest import TestCase
+
+from agent.utils.queue_async_processor import QueueAsyncProcessor
+
+
+class AsyncProcessorTets(TestCase):
+    def test_exception_handling(self):
+        # failing to execute an operation shouldn't stop the processor
+        processor: Optional[QueueAsyncProcessor[str]] = None
+        invocations = []
+
+        def handler(param: str):
+            invocations.append(param)
+            if param == "fail":
+                raise Exception("test")
+            elif param == "stop":
+                if processor:
+                    processor._running = False
+            else:
+                pass
+
+        processor = QueueAsyncProcessor("test", handler, 1)
+        processor.schedule("fail")
+        processor.schedule("ok")
+        processor.schedule("stop")
+        processor._running = True
+        processor._run(0)
+
+        self.assertEqual(3, len(invocations))


### PR DESCRIPTION
We detected that in some cases if an operation fails to be executed, the thread executing them is stopped, this PR catches exceptions to prevent that