### PR TITLE
Update snowflake connector to `3.15.0`

### DIFF
--- a/service/requirements-build.in
+++ b/service/requirements-build.in
@@ -1,2 +1,2 @@
 # dependencies that are built in a separate stage of the docker image
-snowflake-connector-python==3.13.1
+snowflake-connector-python==3.15.0

--- a/service/requirements-build.txt
+++ b/service/requirements-build.txt
@@ -6,6 +6,13 @@
 #
 asn1crypto==1.5.1
     # via snowflake-connector-python
+boto3==1.38.24
+    # via snowflake-connector-python
+botocore==1.38.24
+    # via
+    #   boto3
+    #   s3transfer
+    #   snowflake-connector-python
 certifi==2025.4.26
     # via
     #   requests
@@ -28,6 +35,10 @@ idna==3.10
     # via
     #   requests
     #   snowflake-connector-python
+jmespath==1.0.1
+    # via
+    #   boto3
+    #   botocore
 packaging==25.0
     # via snowflake-connector-python
 platformdirs==4.3.7
@@ -38,11 +49,17 @@ pyjwt==2.10.1
     # via snowflake-connector-python
 pyopenssl==24.3.0
     # via snowflake-connector-python
+python-dateutil==2.9.0.post0
+    # via botocore
 pytz==2025.2
     # via snowflake-connector-python
 requests==2.32.3
     # via snowflake-connector-python
-snowflake-connector-python==3.13.1
+s3transfer==0.13.0
+    # via boto3
+six==1.17.0
+    # via python-dateutil
+snowflake-connector-python==3.15.0
     # via -r requirements-build.in
 sortedcontainers==2.4.0
     # via snowflake-connector-python
@@ -51,4 +68,6 @@ tomlkit==0.13.2
 typing-extensions==4.13.2
     # via snowflake-connector-python
 urllib3==2.4.0
-    # via requests
+    # via
+    #   botocore
+    #   requests

--- a/service/requirements.txt
+++ b/service/requirements.txt
@@ -6,40 +6,40 @@
 #
 asn1crypto==1.5.1
     # via
-    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
+    #   -c requirements-build.txt
     #   snowflake-connector-python
 blinker==1.9.0
     # via flask
 boto3==1.38.24
     # via
-    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
+    #   -c requirements-build.txt
     #   snowflake-connector-python
 botocore==1.38.24
     # via
-    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
+    #   -c requirements-build.txt
     #   boto3
     #   s3transfer
     #   snowflake-connector-python
 certifi==2025.4.26
     # via
-    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
+    #   -c requirements-build.txt
     #   requests
     #   snowflake-connector-python
 cffi==1.17.1
     # via
-    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
+    #   -c requirements-build.txt
     #   cryptography
     #   snowflake-connector-python
 charset-normalizer==3.4.2
     # via
-    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
+    #   -c requirements-build.txt
     #   requests
     #   snowflake-connector-python
 click==8.1.7
     # via flask
 cryptography==44.0.1
     # via
-    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
+    #   -c requirements-build.txt
     #   pyopenssl
     #   snowflake-connector-python
 dataclasses-json==0.6.7
@@ -48,7 +48,7 @@ decorator==5.1.1
     # via retry2
 filelock==3.18.0
     # via
-    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
+    #   -c requirements-build.txt
     #   snowflake-connector-python
 flask==3.0.3
     # via
@@ -60,7 +60,7 @@ gunicorn==23.0.0
     # via -r requirements.in
 idna==3.10
     # via
-    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
+    #   -c requirements-build.txt
     #   requests
     #   snowflake-connector-python
 itsdangerous==2.2.0
@@ -71,7 +71,7 @@ jinja2==3.1.6
     #   flask
 jmespath==1.0.1
     # via
-    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
+    #   -c requirements-build.txt
     #   boto3
     #   botocore
 markupsafe==3.0.2
@@ -84,62 +84,62 @@ mypy-extensions==1.0.0
     # via typing-inspect
 packaging==25.0
     # via
-    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
+    #   -c requirements-build.txt
     #   gunicorn
     #   marshmallow
     #   snowflake-connector-python
 platformdirs==4.3.7
     # via
-    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
+    #   -c requirements-build.txt
     #   snowflake-connector-python
 pycparser==2.22
     # via
-    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
+    #   -c requirements-build.txt
     #   cffi
 pyjwt==2.10.1
     # via
-    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
+    #   -c requirements-build.txt
     #   snowflake-connector-python
 pyopenssl==24.3.0
     # via
-    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
+    #   -c requirements-build.txt
     #   snowflake-connector-python
 python-dateutil==2.9.0.post0
     # via
-    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
+    #   -c requirements-build.txt
     #   botocore
 pytz==2025.2
     # via
-    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
+    #   -c requirements-build.txt
     #   snowflake-connector-python
 redis==5.1.1
     # via flask-sse
 requests==2.32.3
     # via
-    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
+    #   -c requirements-build.txt
     #   snowflake-connector-python
     #   sseclient
 retry2==0.9.5
     # via -r requirements.in
 s3transfer==0.13.0
     # via
-    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
+    #   -c requirements-build.txt
     #   boto3
 six==1.17.0
     # via
-    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
+    #   -c requirements-build.txt
     #   flask-sse
     #   python-dateutil
     #   sseclient
 snowflake-connector-python==3.15.0
     # via
-    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
+    #   -c requirements-build.txt
     #   snowflake-sqlalchemy
 snowflake-sqlalchemy==1.6.1
     # via -r requirements.in
 sortedcontainers==2.4.0
     # via
-    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
+    #   -c requirements-build.txt
     #   snowflake-connector-python
 sqlalchemy==2.0.36
     # via snowflake-sqlalchemy
@@ -147,11 +147,11 @@ sseclient==0.0.27
     # via -r requirements.in
 tomlkit==0.13.2
     # via
-    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
+    #   -c requirements-build.txt
     #   snowflake-connector-python
 typing-extensions==4.13.2
     # via
-    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
+    #   -c requirements-build.txt
     #   snowflake-connector-python
     #   sqlalchemy
     #   typing-inspect
@@ -159,7 +159,7 @@ typing-inspect==0.9.0
     # via dataclasses-json
 urllib3==2.4.0
     # via
-    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
+    #   -c requirements-build.txt
     #   botocore
     #   requests
 werkzeug==3.1.3

--- a/service/requirements.txt
+++ b/service/requirements.txt
@@ -6,30 +6,40 @@
 #
 asn1crypto==1.5.1
     # via
-    #   -c requirements-build.txt
+    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
     #   snowflake-connector-python
 blinker==1.9.0
     # via flask
+boto3==1.38.24
+    # via
+    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
+    #   snowflake-connector-python
+botocore==1.38.24
+    # via
+    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
+    #   boto3
+    #   s3transfer
+    #   snowflake-connector-python
 certifi==2025.4.26
     # via
-    #   -c requirements-build.txt
+    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
     #   requests
     #   snowflake-connector-python
 cffi==1.17.1
     # via
-    #   -c requirements-build.txt
+    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
     #   cryptography
     #   snowflake-connector-python
 charset-normalizer==3.4.2
     # via
-    #   -c requirements-build.txt
+    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
     #   requests
     #   snowflake-connector-python
 click==8.1.7
     # via flask
 cryptography==44.0.1
     # via
-    #   -c requirements-build.txt
+    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
     #   pyopenssl
     #   snowflake-connector-python
 dataclasses-json==0.6.7
@@ -38,7 +48,7 @@ decorator==5.1.1
     # via retry2
 filelock==3.18.0
     # via
-    #   -c requirements-build.txt
+    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
     #   snowflake-connector-python
 flask==3.0.3
     # via
@@ -50,7 +60,7 @@ gunicorn==23.0.0
     # via -r requirements.in
 idna==3.10
     # via
-    #   -c requirements-build.txt
+    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
     #   requests
     #   snowflake-connector-python
 itsdangerous==2.2.0
@@ -59,6 +69,11 @@ jinja2==3.1.6
     # via
     #   -r requirements.in
     #   flask
+jmespath==1.0.1
+    # via
+    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
+    #   boto3
+    #   botocore
 markupsafe==3.0.2
     # via
     #   jinja2
@@ -69,52 +84,62 @@ mypy-extensions==1.0.0
     # via typing-inspect
 packaging==25.0
     # via
-    #   -c requirements-build.txt
+    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
     #   gunicorn
     #   marshmallow
     #   snowflake-connector-python
 platformdirs==4.3.7
     # via
-    #   -c requirements-build.txt
+    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
     #   snowflake-connector-python
 pycparser==2.22
     # via
-    #   -c requirements-build.txt
+    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
     #   cffi
 pyjwt==2.10.1
     # via
-    #   -c requirements-build.txt
+    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
     #   snowflake-connector-python
 pyopenssl==24.3.0
     # via
-    #   -c requirements-build.txt
+    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
     #   snowflake-connector-python
+python-dateutil==2.9.0.post0
+    # via
+    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
+    #   botocore
 pytz==2025.2
     # via
-    #   -c requirements-build.txt
+    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
     #   snowflake-connector-python
 redis==5.1.1
     # via flask-sse
 requests==2.32.3
     # via
-    #   -c requirements-build.txt
+    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
     #   snowflake-connector-python
     #   sseclient
 retry2==0.9.5
     # via -r requirements.in
-six==1.16.0
+s3transfer==0.13.0
     # via
+    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
+    #   boto3
+six==1.17.0
+    # via
+    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
     #   flask-sse
+    #   python-dateutil
     #   sseclient
-snowflake-connector-python==3.13.1
+snowflake-connector-python==3.15.0
     # via
-    #   -c requirements-build.txt
+    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
     #   snowflake-sqlalchemy
 snowflake-sqlalchemy==1.6.1
     # via -r requirements.in
 sortedcontainers==2.4.0
     # via
-    #   -c requirements-build.txt
+    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
     #   snowflake-connector-python
 sqlalchemy==2.0.36
     # via snowflake-sqlalchemy
@@ -122,11 +147,11 @@ sseclient==0.0.27
     # via -r requirements.in
 tomlkit==0.13.2
     # via
-    #   -c requirements-build.txt
+    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
     #   snowflake-connector-python
 typing-extensions==4.13.2
     # via
-    #   -c requirements-build.txt
+    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
     #   snowflake-connector-python
     #   sqlalchemy
     #   typing-inspect
@@ -134,7 +159,8 @@ typing-inspect==0.9.0
     # via dataclasses-json
 urllib3==2.4.0
     # via
-    #   -c requirements-build.txt
+    #   -c /Users/mrostan/Developer/mc/sna-artemis-agent/service/requirements-build.txt
+    #   botocore
     #   requests
 werkzeug==3.1.3
     # via


### PR DESCRIPTION
- We started getting errors accessing the stage (a bucket when SF is deployed in AWS) and it is fixed by upgrading the Snowflake connector to the latest version (`3.15.0`)
- More information [here](https://github.com/orgs/community/discussions/157821) and [here](https://status.snowflake.com/incidents/txclg2cyzq32)