### PR TITLE
SNA: provide a way to run queries by the application itself

### DIFF
--- a/service/agent/sna/queries_service.py
+++ b/service/agent/sna/queries_service.py
@@ -183,13 +183,15 @@ class QueriesService:
                 if self._direct_sync_queries or self._use_sync_query(sql_query):
                     cur.execute(sql_query)
                     logger.info(
-                        f"Sync query executed: {operation_id} {sql_query}, id: {cur.sfqid}"
+                        f"Sync query executed ({operation_id}): {get_query_for_logs(sql_query)}, id: {cur.sfqid}"
                     )
                     return self._result_for_cursor(cur)
                 elif self._helper_sync_queries:
                     cur.execute(QUERY_SET_STATEMENT_TIMEOUT.format(timeout=timeout))
                     cur.execute(QUERY_EXECUTE_QUERY_WITH_HELPER_SYNC, [sql_query])
-                    logger.info(f"Sync query executed: {operation_id} {sql_query}")
+                    logger.info(
+                        f"Sync query executed by helper ({operation_id}): {get_query_for_logs(sql_query)}"
+                    )
                     return self._result_for_cursor(cur)
                 else:
                     operation_json = query.operation_attrs.to_json()

--- a/service/agent/sna/queries_service.py
+++ b/service/agent/sna/queries_service.py
@@ -180,7 +180,7 @@ class QueriesService:
         sql_query = query.query
         with self._connect(query.operation_attrs.job_type) as conn:
             with conn.cursor() as cur:
-                if self._direct_sync_queries:
+                if self._direct_sync_queries or self._use_sync_query(sql_query):
                     cur.execute(sql_query)
                     logger.info(
                         f"Sync query executed: {operation_id} {sql_query}, id: {cur.sfqid}"
@@ -201,6 +201,10 @@ class QueriesService:
                         f"Async query executed: {operation_id} {get_query_for_logs(sql_query)}, id: {cur.sfqid}"
                     )
                     return None
+
+    @staticmethod
+    def _use_sync_query(query: str) -> bool:
+        return "--mcd_query_use_application" in query
 
     @staticmethod
     def _get_error_message(msg: str) -> str:

--- a/service/agent/utils/queue_async_processor.py
+++ b/service/agent/utils/queue_async_processor.py
@@ -10,7 +10,8 @@ T = TypeVar("T")
 class QueueAsyncProcessor(Generic[T]):
     """
     Base class used to process operations in a queue asynchronously.
-    Currently, it uses a single thread to process the operations.
+    It is configured with the handler that will be called for each operation in the queue,
+    and the number of threads used to execute them in parallel.
     """
 
     def __init__(self, name: str, handler: Callable[[T], None], thread_count: int):

--- a/service/agent/utils/queue_async_processor.py
+++ b/service/agent/utils/queue_async_processor.py
@@ -51,14 +51,15 @@ class QueueAsyncProcessor(Generic[T]):
                     self._condition.wait()
                 if not self._running:
                     break
-                to_execute = self._queue.copy()
-                self._queue.clear()
-            for o in to_execute:
-                self._invoke_handler(o)
-        logger.info(f"{thread_name} stopped")
+                to_execute = self._queue.pop(0)
 
-    def _invoke_handler(self, param: Any):
+            self._invoke_handler(thread_name, to_execute)
+        logger.info(f"{thread_name}: stopped")
+
+    def _invoke_handler(self, thread_name: str, param: Any):
         try:
+            logger.info(f"{thread_name}: running operation")
             self._handler(param)
+            logger.info(f"{thread_name}: completed operation")
         except Exception as ex:
-            logger.exception(f"Failed to run operation: {ex}")
+            logger.exception(f"{thread_name}: Failed to run operation: {ex}")


### PR DESCRIPTION
- We're having issues in one customer with no data returned for some monitors and we think it might be related to the stored procedure we use to execute them
- This PR provides a way (by adding the following comment to the SQL query: `--mcd_query_use_application`) to mark a query to be executed by the application itself instead of using the stored procedure
- The async processor is also improved to take only the next operation in the queue, to improve parallelization as in order to use the feature above we need to increase the number of threads executing queries