### PR TITLE
MES-1559: add request timeout when pushing results to MC backend

### DIFF
--- a/service/agent/backend/backend_client.py
+++ b/service/agent/backend/backend_client.py
@@ -48,6 +48,7 @@ class BackendClient:
                 "Content-Type": "application/json",
                 **get_mc_login_token(),
             },
+            timeout=60,
         )
         logger.info(
             f"Sent query results to backend, operation_id: {operation_id}, response: {response.status_code}"

--- a/service/tests/test_app_service.py
+++ b/service/tests/test_app_service.py
@@ -139,6 +139,7 @@ class AppServiceTests(TestCase):
                 "x-mcd-id": "local-token-id",
                 "x-mcd-token": "local-token-secret",
             },
+            timeout=60,
         )
         url = mock_requests_put.call_args[0][0]
         self.assertTrue(url.endswith("/api/v1/agent/operations/1234/result"))


### PR DESCRIPTION
This PR adds a 60s timeout when the agent attempts to send operation results to the Orchestrator.

To verify expected behavior in dev, I added a 65s sleep in the Orchestrator handler for these requests and verified timeouts in Datadog:
```
WARNING:retry.api: ReadTimeout: HTTPSConnectionPool(host='artemis.dev.getmontecarlo.com', port=443): Read timed out. (read timeout=60) in agent.backend.backend_client.BackendClient._push_results_with_retries, retrying in 1 seconds...
```
```
WARNING:retry.api: ReadTimeout: HTTPSConnectionPool(host='artemis.dev.getmontecarlo.com', port=443): Read timed out. (read timeout=60) in agent.backend.backend_client.BackendClient._push_results_with_retries, retrying in 2 seconds...
```
```
ERROR:agent.backend.backend_client: Failed to push results to backend: HTTPSConnectionPool(host='artemis.dev.getmontecarlo.com', port=443): Read timed out. (read timeout=60)
```
