### PR TITLE
Removing HIGHMEM_X64_SL as Snowflake removed compatibility with this instance family on AWS

### DIFF
--- a/app/marketplace.yml
+++ b/app/marketplace.yml
@@ -10,7 +10,6 @@ required_compute_pools:
         - HIGHMEM_X64_S
         - HIGHMEM_X64_M
         - HIGHMEM_X64_L
-        - HIGHMEM_X64_SL
 connections:
   - MONTE_CARLO:
      label: "Monte Carlo"


### PR DESCRIPTION
See details [here](https://montecarlodata.slack.com/archives/C092HRW8K62/p1755129957564259).