### PR TITLE
Upgrade agent-common + fix graceful shutdown signal handling

### DIFF
--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -18,6 +18,7 @@ ENV PATH="/opt/venv/bin:$PATH"
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
+COPY gunicorn.conf.py ./
 COPY agent/ ./agent
 
 ARG code_version="local"
@@ -52,10 +53,11 @@ RUN adduser --disabled-password mcdagent
 
 COPY --from=base --chown=mcdagent /opt/venv /opt/venv
 COPY --from=base --chown=mcdagent /agent /agent
+COPY --from=base --chown=mcdagent /gunicorn.conf.py /gunicorn.conf.py
 
 USER mcdagent
 
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
-CMD ["gunicorn", "agent.main:app", "--bind", "0.0.0.0:8000"]
+CMD ["gunicorn", "--config", "gunicorn.conf.py", "agent.main:app", "--bind", "0.0.0.0:8000"]

--- a/service/agent/main.py
+++ b/service/agent/main.py
@@ -1,9 +1,6 @@
 import json
 import logging
 import os
-import signal
-import sys
-from typing import Any
 
 from apollo.egress.agent.config.config_manager import ConfigurationManager
 from apollo.egress.agent.config.local_config import LocalConfig
@@ -42,16 +39,6 @@ service = SnaService(
         )
     )
 )
-
-
-def handler(signum: int, frame: Any):
-    print("Signal handler called with signal", signum)
-    service.stop()
-    print("Signal handler completed")
-    sys.exit(0)
-
-
-signal.signal(signal.SIGINT, handler)
 
 
 @app.get("/api/v1/test/healthcheck")
@@ -171,4 +158,5 @@ service.start()
 
 if __name__ == "__main__":
     # only used for local development, when gunicorn is not used
+    service.register_signal_handlers()
     app.run(host=SERVICE_HOST, port=int(SERVICE_PORT))

--- a/service/gunicorn.conf.py
+++ b/service/gunicorn.conf.py
@@ -1,0 +1,14 @@
+"""Gunicorn configuration for sna-artemis-agent.
+
+The post_worker_init hook registers signal handlers after gunicorn has
+finished initializing the worker (including setting up its own signal
+handlers). Without this, gunicorn's init_signals() overrides the
+application's handlers, and graceful shutdown logic (notify orchestrator,
+stop threads) won't run on workers that receive SIGTERM.
+"""
+
+
+def post_worker_init(worker: object) -> None:
+    from agent.main import service
+
+    service.register_signal_handlers()

--- a/service/requirements-build.in
+++ b/service/requirements-build.in
@@ -1,5 +1,5 @@
 # dependencies that are built in a separate stage of the docker image
-agent-common @ git+https://github.com/monte-carlo-data/agent-common.git@cfritz/refactor-agent-health-tracking
+agent-common @ git+https://github.com/monte-carlo-data/agent-common.git@v0.2.0
 
 snowflake-connector-python==3.15.0
 requests>=2.32.4 # Upgraded in VULN-616

--- a/service/requirements-build.in
+++ b/service/requirements-build.in
@@ -1,5 +1,5 @@
 # dependencies that are built in a separate stage of the docker image
-agent-common @ git+https://github.com/monte-carlo-data/agent-common.git@v0.1.2
+agent-common @ git+https://github.com/monte-carlo-data/agent-common.git@cfritz/refactor-agent-health-tracking
 
 snowflake-connector-python==3.15.0
 requests>=2.32.4 # Upgraded in VULN-616

--- a/service/requirements-build.txt
+++ b/service/requirements-build.txt
@@ -6,7 +6,7 @@
 #
 agent-base @ git+https://github.com/monte-carlo-data/agent-base.git@v0.0.2
     # via agent-common
-agent-common @ git+https://github.com/monte-carlo-data/agent-common.git@v0.1.2
+agent-common @ git+https://github.com/monte-carlo-data/agent-common.git@cfritz/refactor-agent-health-tracking
     # via -r requirements-build.in
 asn1crypto==1.5.1
     # via snowflake-connector-python

--- a/service/requirements-build.txt
+++ b/service/requirements-build.txt
@@ -6,7 +6,7 @@
 #
 agent-base @ git+https://github.com/monte-carlo-data/agent-base.git@v0.0.2
     # via agent-common
-agent-common @ git+https://github.com/monte-carlo-data/agent-common.git@cfritz/refactor-agent-health-tracking
+agent-common @ git+https://github.com/monte-carlo-data/agent-common.git@v0.2.0
     # via -r requirements-build.in
 asn1crypto==1.5.1
     # via snowflake-connector-python

--- a/service/tests/test_app_service.py
+++ b/service/tests/test_app_service.py
@@ -156,6 +156,7 @@ class AppServiceTests(TestCase):
                 "Content-Type": "application/json",
                 "x-mcd-id": "local-token-id",
                 "x-mcd-token": "local-token-secret",
+                "x-mcd-agent-instance-id": ANY,
             },
             timeout=60,
         )
@@ -363,6 +364,7 @@ class AppServiceTests(TestCase):
                 headers={
                     "x-mcd-id": "local-token-id",
                     "x-mcd-token": "local-token-secret",
+                    "x-mcd-agent-instance-id": ANY,
                 },
             )
             self.assertEqual(health_response, result)


### PR DESCRIPTION
## Summary

- Upgrade `agent-common` from v0.1.2 to v0.2.0
- Fix graceful shutdown by moving signal handler registration to a gunicorn `post_worker_init` hook — gunicorn's `init_signals()` was overriding app-level handlers set at module load time, preventing the service's shutdown logic (orchestrator notification, thread cleanup) from running on SIGTERM
- Add `gunicorn.conf.py` for the hook and update the Dockerfile CMD to use it
- Fix unit tests for new `x-mcd-agent-instance-id` header from agent-common upgrade

## Test plan

- [x] Unit tests pass (`pytest`)
- [x] Verify graceful shutdown: deploy to a test environment, send SIGTERM to gunicorn worker, confirm shutdown logic executes (orchestrator notified, threads stopped)
- [x] Verify healthcheck endpoint still works after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)