### PR TITLE
chore(security): bump gunicorn 23.0.0 -> 26.0.0 (YET-1356)

### DIFF
--- a/service/requirements.in
+++ b/service/requirements.in
@@ -2,7 +2,7 @@
 dataclasses-json==0.6.7
 flask==3.0.3
 flask-sse==1.0.0
-gunicorn==23.0.0
+gunicorn==26.0.0  # YET-1356 / VULN-1117: request-smuggling & header-framing hardening (AIKIDO-2026-10742); default sync worker, post_worker_init hook unaffected
 jinja2==3.1.6  # VULN-492 - Tried upgrading to flask 3.1.0 but it was still using jinja2 3.1.4
 retry2==0.9.5
 snowflake-sqlalchemy==1.6.1

--- a/service/requirements.txt
+++ b/service/requirements.txt
@@ -60,7 +60,7 @@ flask==3.0.3
     #   flask-sse
 flask-sse==1.0.0
     # via -r requirements.in
-gunicorn==23.0.0
+gunicorn==26.0.0
     # via -r requirements.in
 idna==3.11
     # via


### PR DESCRIPTION
## What
Bumps **gunicorn 23.0.0 → 26.0.0** (`service/requirements.{in,txt}`) to close the gunicorn HIGH finding (AIKIDO-2026-10742). 26.0.0's stricter RFC 9112/9110 request parsing fixes the request-smuggling / header-framing hazards. pip-compile moved only the gunicorn pin — no transitive churn.

sna-artemis-agent does **not** depend on apollo-agent, so this is a direct bump (independent of the apollo-agent 1.7.2 release).

## Why it's safe
- Python 3.12 (Dockerfile) satisfies gunicorn 26's `>=3.10` floor.
- Launches the **default sync worker** (`CMD gunicorn --config gunicorn.conf.py agent.main:app`); the 26.0.0 eventlet-worker removal doesn't apply.
- `service/gunicorn.conf.py` uses only the `post_worker_init` hook (no gunicorn internals, no `worker_class`) — verified `post_worker_init` is still a valid setting in gunicorn 26.0.0.

## Context
- [YET-1356](https://linear.app/montecarloai/issue/YET-1356/yeti-gunicorn) / parent [VULN-1117](https://linear.app/montecarloai/issue/VULN-1117/major-upgrade-for-gunicorn)
- Sibling PRs: apollo-agent #312 (merged), data-collector #2376, monolith-django #13709

## Checklist
- [x] Verified gunicorn 26 compat (sync worker, `post_worker_init` hook valid, Python 3.12)
- [na] Unit tests — pure dependency version bump, no code change
- [ ] Validated on dev
- [ ] Re-scan in Aikido after release

🤖 Generated with [Claude Code](https://claude.com/claude-code)