### PR TITLE
chore(security): fix HIGH vulns in SNA agent (deps + base image)

### DIFF
--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -9,6 +9,9 @@ RUN apk add build-base gcc musl-dev python3-dev libffi-dev openssl-dev cargo pkg
 COPY requirements-build.txt .
 RUN pip install -r requirements-build.txt
 
+# VULN: CVE-2025-47273 (setuptools), CVE-2026-24049 (wheel) — patch venv build tooling
+RUN pip install --no-cache-dir --upgrade "setuptools>=78.1.1" "wheel>=0.46.2"
+
 FROM python:3.12-alpine3.21 AS base
 
 COPY --from=builder /opt/venv /opt/venv
@@ -41,13 +44,17 @@ FROM python:3.12-alpine3.21 AS final
 # update openssl
 RUN apk update && apk add --no-cache openssl~3.3
 
+# VULN: CVE-2026-40200 - upgrade musl (and musl-utils, same source pkg) to patched 3.21 release
+RUN apk add --no-cache --upgrade "musl>=1.2.5-r11" "musl-utils>=1.2.5-r11"
+
 # VULN-557 - Upgrade sqlite-libs to 3.49.1
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories
 RUN apk add "sqlite-libs>=3.49.1"
 
 # upgrade global libraries to fix CVEs. Upgrade pip to fix VULN-510
+# setuptools: CVE-2025-47273 (fix 78.1.1); wheel: CVE-2026-24049 (fix 0.46.2)
 RUN pip install --no-cache-dir --upgrade pip==25.0.0 && \
-    pip install --no-cache-dir --upgrade setuptools==75.1.0
+    pip install --no-cache-dir --upgrade setuptools==78.1.1 wheel==0.46.2
 
 RUN adduser --disabled-password mcdagent
 

--- a/service/requirements-build.in
+++ b/service/requirements-build.in
@@ -1,6 +1,10 @@
 # dependencies that are built in a separate stage of the docker image
 agent-common @ git+https://github.com/monte-carlo-data/agent-common.git@v0.2.1
 
-snowflake-connector-python==3.15.0
+snowflake-connector-python==4.4.0 # Bumped from 3.15.0; lifts pyOpenSSL<26 cap (matches apollo-agent)
 requests>=2.32.4 # Upgraded in VULN-616
-urllib3>=2.6.0 # Upgraded for agent-common compatibility
+urllib3>=2.7.0 # Upgraded for agent-common compatibility; CVE-2026-44431 / CVE-2026-44432
+# Security floors for transitive deps pulled by snowflake-connector-python (see #collection-agent-vuln-scans)
+cryptography>=46.0.5 # CVE-2026-26007
+pyjwt>=2.13.0 # CVE-2026-32597 / CVE-2026-48526 / CVE-2025-45768
+pyopenssl>=26.0.0 # CVE-2026-27459

--- a/service/requirements-build.txt
+++ b/service/requirements-build.txt
@@ -23,16 +23,15 @@ certifi==2025.11.12
     # via
     #   requests
     #   snowflake-connector-python
-cffi==1.17.1
-    # via
-    #   cryptography
-    #   snowflake-connector-python
+cffi==2.0.0
+    # via cryptography
 charset-normalizer==3.4.4
     # via
     #   requests
     #   snowflake-connector-python
-cryptography==46.0.0
+cryptography==46.0.5
     # via
+    #   -r requirements-build.in
     #   pyopenssl
     #   snowflake-connector-python
 dataclasses-json==0.6.7
@@ -61,10 +60,14 @@ platformdirs==4.5.1
     # via snowflake-connector-python
 pycparser==2.23
     # via cffi
-pyjwt==2.10.1
-    # via snowflake-connector-python
-pyopenssl==25.3.0
-    # via snowflake-connector-python
+pyjwt==2.13.0
+    # via
+    #   -r requirements-build.in
+    #   snowflake-connector-python
+pyopenssl==26.2.0
+    # via
+    #   -r requirements-build.in
+    #   snowflake-connector-python
 python-dateutil==2.9.0.post0
     # via botocore
 pytz==2025.2
@@ -84,7 +87,7 @@ six==1.17.0
     # via
     #   python-dateutil
     #   sseclient
-snowflake-connector-python==3.15.0
+snowflake-connector-python==4.4.0
     # via -r requirements-build.in
 sortedcontainers==2.4.0
     # via snowflake-connector-python
@@ -99,7 +102,7 @@ typing-extensions==4.15.0
     #   typing-inspect
 typing-inspect==0.9.0
     # via dataclasses-json
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -r requirements-build.in
     #   agent-common

--- a/service/requirements.in
+++ b/service/requirements.in
@@ -5,6 +5,6 @@ flask-sse==1.0.0
 gunicorn==26.0.0  # YET-1356 / VULN-1117: request-smuggling & header-framing hardening (AIKIDO-2026-10742); default sync worker, post_worker_init hook unaffected
 jinja2==3.1.6  # VULN-492 - Tried upgrading to flask 3.1.0 but it was still using jinja2 3.1.4
 retry2==0.9.5
-snowflake-sqlalchemy==1.6.1
+snowflake-sqlalchemy==1.10.0  # Bumped from 1.6.1 to allow snowflake-connector-python 4.x
 sseclient==0.0.27
 werkzeug==3.1.3

--- a/service/requirements.txt
+++ b/service/requirements.txt
@@ -25,11 +25,10 @@ certifi==2025.11.12
     #   -c requirements-build.txt
     #   requests
     #   snowflake-connector-python
-cffi==1.17.1
+cffi==2.0.0
     # via
     #   -c requirements-build.txt
     #   cryptography
-    #   snowflake-connector-python
 charset-normalizer==3.4.4
     # via
     #   -c requirements-build.txt
@@ -37,7 +36,7 @@ charset-normalizer==3.4.4
     #   snowflake-connector-python
 click==8.3.1
     # via flask
-cryptography==46.0.0
+cryptography==46.0.5
     # via
     #   -c requirements-build.txt
     #   pyopenssl
@@ -60,6 +59,8 @@ flask==3.0.3
     #   flask-sse
 flask-sse==1.0.0
     # via -r requirements.in
+greenlet==3.5.1
+    # via sqlalchemy
 gunicorn==26.0.0
     # via -r requirements.in
 idna==3.11
@@ -104,11 +105,11 @@ pycparser==2.23
     # via
     #   -c requirements-build.txt
     #   cffi
-pyjwt==2.10.1
+pyjwt==2.13.0
     # via
     #   -c requirements-build.txt
     #   snowflake-connector-python
-pyopenssl==25.3.0
+pyopenssl==26.2.0
     # via
     #   -c requirements-build.txt
     #   snowflake-connector-python
@@ -141,11 +142,11 @@ six==1.17.0
     #   flask-sse
     #   python-dateutil
     #   sseclient
-snowflake-connector-python==3.15.0
+snowflake-connector-python==4.4.0
     # via
     #   -c requirements-build.txt
     #   snowflake-sqlalchemy
-snowflake-sqlalchemy==1.6.1
+snowflake-sqlalchemy==1.10.0
     # via -r requirements.in
 sortedcontainers==2.4.0
     # via
@@ -172,7 +173,7 @@ typing-inspect==0.9.0
     # via
     #   -c requirements-build.txt
     #   dataclasses-json
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -c requirements-build.txt
     #   botocore


### PR DESCRIPTION
## Summary

Addresses **all 10 HIGH** findings from `#collection-agent-vuln-scans` for the SNA agent (latest scan 2026-06-03). No criticals present.

### Python deps (recompiled via `pip-compile` in a `python:3.12-alpine3.21` container)
| CVE | Package | Fix |
|-----|---------|-----|
| CVE-2026-26007 | cryptography | 46.0.0 → 46.0.5 |
| CVE-2026-32597 / CVE-2026-48526 / CVE-2025-45768 | pyjwt | 2.10.1 → 2.13.0 |
| CVE-2026-44431 / CVE-2026-44432 | urllib3 | 2.6.3 → 2.7.0 |
| CVE-2026-27459 | pyopenssl | 25.3.0 → 26.2.0 |

The pyopenssl 26.x fix required lifting the connector's `pyOpenSSL<26` cap:
- `snowflake-connector-python` 3.15.0 → **4.4.0** (matches apollo-agent)
- `snowflake-sqlalchemy` 1.6.1 → **1.10.0** (allows connector 4.x)

### Dockerfile (build / OS layer)
| CVE | Package | Fix |
|-----|---------|-----|
| CVE-2025-47273 | setuptools | 75.1.0 → 78.1.1 |
| CVE-2026-24049 | wheel | 0.43.0 → 0.46.2 |
| CVE-2026-40200 | musl + musl-utils | 1.2.5-r9 → 1.2.5-r11 |

## ⚠️ Reviewer attention
`snowflake-sqlalchemy` 1.10.0 pulls **SQLAlchemy 1.4.x → 2.0.45**. `service/agent/sna/queries_service.py` uses `SnowflakeDialect` + `QueuePool`; both still work and unit tests pass, but the tests mock the Snowflake connection — worth a careful look / live validation in dev.

## Testing
- `docker build --target tests` → **51/51 passed**
- Final image inspected: all patched versions confirmed in both `/opt/venv` and `/usr/local` site-packages, and `apk list` shows musl/musl-utils at r11.
- Will validate live in `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)