### PR TITLE
chore(security): fix HIGH vulns — cryptography 48.0.1, wheel 0.47.0

### DIFF
--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -10,7 +10,7 @@ COPY requirements-build.txt .
 RUN pip install -r requirements-build.txt
 
 # VULN: CVE-2025-47273 (setuptools), CVE-2026-24049 (wheel) — patch venv build tooling
-RUN pip install --no-cache-dir --upgrade "setuptools>=78.1.1" "wheel>=0.46.2"
+RUN pip install --no-cache-dir --upgrade "setuptools>=78.1.1" "wheel>=0.47.0"
 
 FROM python:3.13-alpine3.21 AS base
 
@@ -54,7 +54,7 @@ RUN apk add "sqlite-libs>=3.49.1"
 # upgrade global libraries to fix CVEs. Upgrade pip to fix VULN-510
 # setuptools: CVE-2025-47273 (fix 78.1.1); wheel: CVE-2026-24049 (fix 0.46.2)
 RUN pip install --no-cache-dir --upgrade pip==25.0.0 && \
-    pip install --no-cache-dir --upgrade setuptools==78.1.1 wheel==0.46.2
+    pip install --no-cache-dir --upgrade setuptools==78.1.1 wheel==0.47.0
 
 RUN adduser --disabled-password mcdagent
 

--- a/service/requirements-build.in
+++ b/service/requirements-build.in
@@ -5,6 +5,6 @@ snowflake-connector-python==4.4.0 # Bumped from 3.15.0; lifts pyOpenSSL<26 cap (
 requests>=2.32.4 # Upgraded in VULN-616
 urllib3>=2.7.0 # Upgraded for agent-common compatibility; CVE-2026-44431 / CVE-2026-44432
 # Security floors for transitive deps pulled by snowflake-connector-python (see #collection-agent-vuln-scans)
-cryptography>=46.0.5 # CVE-2026-26007
+cryptography>=48.0.1 # CVE-2026-26007 / GHSA-537c-gmf6-5ccf
 pyjwt>=2.13.0 # CVE-2026-32597 / CVE-2026-48526 / CVE-2025-45768
 pyopenssl>=26.0.0 # CVE-2026-27459

--- a/service/requirements-build.txt
+++ b/service/requirements-build.txt
@@ -29,7 +29,7 @@ charset-normalizer==3.4.4
     # via
     #   requests
     #   snowflake-connector-python
-cryptography==46.0.5
+cryptography==48.0.1
     # via
     #   -r requirements-build.in
     #   pyopenssl

--- a/service/requirements-dev.in
+++ b/service/requirements-dev.in
@@ -1,6 +1,6 @@
 -c requirements.txt
 pytest==8.3.3
-pip-tools==7.4.1
+pip-tools==7.5.3
 black==24.10.0
 pre-commit==4.0.1
 pyright==1.1.337

--- a/service/requirements-dev.txt
+++ b/service/requirements-dev.txt
@@ -39,9 +39,10 @@ packaging==25.0
     #   black
     #   build
     #   pytest
+    #   wheel
 pathspec==0.12.1
     # via black
-pip-tools==7.4.1
+pip-tools==7.5.3
     # via -r requirements-dev.in
 platformdirs==4.5.1
     # via
@@ -64,7 +65,7 @@ pyyaml==6.0.3
     # via pre-commit
 virtualenv==20.35.4
     # via pre-commit
-wheel==0.45.1
+wheel==0.47.0
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/service/requirements.txt
+++ b/service/requirements.txt
@@ -36,7 +36,7 @@ charset-normalizer==3.4.4
     #   snowflake-connector-python
 click==8.3.1
     # via flask
-cryptography==46.0.5
+cryptography==48.0.1
     # via
     #   -c requirements-build.txt
     #   pyopenssl


### PR DESCRIPTION
## Summary

Fixes the two fixable HIGH findings reported in **#collection-agent-vuln-scans** (SNA Agent) and flagged by Aikido's repo scan.

| Advisory | Package | Before → After |
|---|---|---|
| `GHSA-537c-gmf6-5ccf` | cryptography | `46.0.5` → `48.0.1` |
| `CVE-2026-24049` | wheel | `0.45.1` → `0.47.0` |

### cryptography (`GHSA-537c-gmf6-5ccf`, HIGH, CVSS 7.5)
Out-of-bounds read in the OpenSSL statically linked into cryptography's prebuilt wheels for all versions `< 48.0.1`. The advisory was **published 2026-06-09 — after** the prior `46.0.5` bump (which fixed the earlier `CVE-2026-26007`), which is why `46.0.5` keeps getting flagged.
- `requirements-build.in`: floor `>=46.0.5` → `>=48.0.1`
- `requirements-build.txt` + `requirements.txt`: recompiled pin → `48.0.1`
- Compatible with pyOpenSSL 26.2.0 (`<49,>=46.0.0`) and snowflake-connector-python 4.4.0 (`>=46.0.5`, no cap). No new transitive deps (`cffi`/`pycparser` already satisfy 48.0.1).

### wheel (`CVE-2026-24049`, HIGH)
`wheel` is a transitive dev dependency via `pip-tools`. Aikido analyzes the requirements files directly (not just the built image), so the dev pin had to be updated.
- `requirements-dev.in`: `pip-tools 7.4.1` → `7.5.3`; recompile pulled `wheel 0.45.1` → `0.47.0`
- `Dockerfile`: build-tooling wheel pins (`>=0.46.2` builder, `==0.46.2` final) bumped to `0.47.0` for consistency

`agent-common` is already on the latest release (`v0.2.7`); no update available.

## Test plan
- [x] `docker build --target tests` (linux/amd64) green — **59/59 tests pass**
- [x] Verified built image installs `cryptography==48.0.1` and `wheel==0.47.0`
- [ ] CircleCI `run-linter` + `run-test-docker` green
- [ ] Merge to `dev` and confirm dev deploy build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
