### PR TITLE
chore(security): remove global setuptools that shipped vulnerable vendored wheel (CVE-2026-24049)

### DIFF
--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -9,8 +9,9 @@ RUN apk add build-base gcc musl-dev python3-dev libffi-dev openssl-dev cargo pkg
 COPY requirements-build.txt .
 RUN pip install -r requirements-build.txt
 
-# VULN: CVE-2025-47273 (setuptools), CVE-2026-24049 (wheel) — patch venv build tooling
-RUN pip install --no-cache-dir --upgrade "setuptools>=78.1.1" "wheel>=0.47.0"
+# VULN: CVE-2025-47273 (setuptools), CVE-2026-24049 (wheel) — patch venv build tooling.
+# setuptools>=81.0.0 also vendors patched wheel 0.46.3 under setuptools/_vendor/.
+RUN pip install --no-cache-dir --upgrade "setuptools>=81.0.0" "wheel>=0.47.0"
 
 FROM python:3.13-alpine3.21 AS base
 
@@ -50,11 +51,6 @@ RUN apk add --no-cache --upgrade "musl>=1.2.5-r11" "musl-utils>=1.2.5-r11"
 # VULN-557 - Upgrade sqlite-libs to 3.49.1
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories
 RUN apk add "sqlite-libs>=3.49.1"
-
-# upgrade global libraries to fix CVEs. Upgrade pip to fix VULN-510
-# setuptools: CVE-2025-47273 (fix 78.1.1); wheel: CVE-2026-24049 (fix 0.46.2)
-RUN pip install --no-cache-dir --upgrade pip==25.0.0 && \
-    pip install --no-cache-dir --upgrade setuptools==78.1.1 wheel==0.47.0
 
 RUN adduser --disabled-password mcdagent
 

--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -9,9 +9,11 @@ RUN apk add build-base gcc musl-dev python3-dev libffi-dev openssl-dev cargo pkg
 COPY requirements-build.txt .
 RUN pip install -r requirements-build.txt
 
-# VULN: CVE-2025-47273 (setuptools), CVE-2026-24049 (wheel) — patch venv build tooling.
-# setuptools>=81.0.0 also vendors patched wheel 0.46.3 under setuptools/_vendor/.
-RUN pip install --no-cache-dir --upgrade "setuptools>=81.0.0" "wheel>=0.47.0"
+# VULN: patch venv build tooling.
+#   setuptools: CVE-2025-47273 — also >=81.0.0 vendors patched wheel 0.46.3 under setuptools/_vendor/.
+#   wheel:      CVE-2026-24049.
+#   pip:        CVE-2026-8643 / CVE-2026-6357 / CVE-2026-3219 / CVE-2026-1703 (fix 26.1.2).
+RUN pip install --no-cache-dir --upgrade "pip>=26.1.2" "setuptools>=81.0.0" "wheel>=0.47.0"
 
 FROM python:3.13-alpine3.21 AS base
 
@@ -51,6 +53,10 @@ RUN apk add --no-cache --upgrade "musl>=1.2.5-r11" "musl-utils>=1.2.5-r11"
 # VULN-557 - Upgrade sqlite-libs to 3.49.1
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories
 RUN apk add "sqlite-libs>=3.49.1"
+
+# VULN: upgrade the base image's global pip (build-time tooling, unused at runtime) —
+# CVE-2026-8643 / CVE-2026-6357 / CVE-2026-3219 / CVE-2026-1703 (fix 26.1.2).
+RUN pip install --no-cache-dir --upgrade "pip>=26.1.2"
 
 RUN adduser --disabled-password mcdagent
 

--- a/service/requirements.in
+++ b/service/requirements.in
@@ -7,4 +7,4 @@ jinja2==3.1.6  # VULN-492 - Tried upgrading to flask 3.1.0 but it was still usin
 retry2==0.9.5
 snowflake-sqlalchemy==1.10.0  # Bumped from 1.6.1 to allow snowflake-connector-python 4.x
 sseclient==0.0.27
-werkzeug==3.1.3
+werkzeug==3.1.6  # VULN: CVE-2026-27199 / CVE-2026-21860 / CVE-2025-66221 (fix 3.1.6)

--- a/service/requirements.txt
+++ b/service/requirements.txt
@@ -177,7 +177,7 @@ urllib3==2.7.0
     #   -c requirements-build.txt
     #   botocore
     #   requests
-werkzeug==3.1.3
+werkzeug==3.1.6
     # via
     #   -r requirements.in
     #   flask


### PR DESCRIPTION
## Problem

CVE-2026-24049 (`wheel`, HIGH) kept being reported by Scout even after #66 bumped the standalone `wheel` to `0.47.0`. Scout flagged:

```
/usr/local/lib/python3.13/site-packages/setuptools/_vendor/wheel-0.45.1.dist-info/METADATA
```

That path is the copy of `wheel` that **setuptools vendors inside itself** (`setuptools/_vendor/`), not the standalone `wheel` package — so bumping standalone `wheel` never touched it.

## Root cause

The final-stage `pip install ... setuptools==78.1.1 wheel==0.47.0` was a stale **Python 3.11-era template line**:

| Base image | ships setuptools/wheel globally? |
|---|---|
| `python:3.11-alpine` | ✅ yes |
| `python:3.12-alpine` / `3.13-alpine` | ❌ only pip |

On 3.11, upgrading the global setuptools/wheel made sense. This repo has always been on 3.12+, so that line stopped *upgrading* anything and instead **introduced** setuptools — and its vendored `wheel-0.45.1` — into the global site-packages, creating the very finding Scout reports. The app runs entirely from `/opt/venv`, so nothing needs setuptools/wheel globally.

## Changes

**Primary fix (HIGH — CVE-2026-24049):**
- **Drop** the global `setuptools`/`wheel` install from the final stage (eliminates the vendored-wheel finding at the source).
- **Drop** the `pip==25.0.0` pin — it was a *downgrade* (the base image already ships pip 25.3, which covers VULN-510).
- **Raise** the builder-stage floor to `setuptools>=81.0.0` (first version vendoring patched `wheel 0.46.3`), so the venv's own vendored wheel is clean too.

**Follow-on (MEDIUM/LOW cleanups found via a full Scout scan):**
- **pip 25.3 → 26.1.2** — clears CVE-2026-8643, CVE-2026-6357, CVE-2026-3219 (M) + CVE-2026-1703 (L). pip is build-time-only tooling; CVEs are install-time attacks — belt-and-suspenders to satisfy the scanner.
- **werkzeug 3.1.3 → 3.1.6** — clears CVE-2026-27199, CVE-2026-21860, CVE-2025-66221 (M). All "Windows device name" issues, not reachable on Alpine; patch bump within 3.1.x, recompiled lock with no transitive changes.

## Verification

- `docker build --target tests` (linux/amd64) green — **59/59 tests pass**.
- **Docker Scout** on the built image: **0C / 0H** (was 1 HIGH). Full-severity total dropped **14M/6L → 8M/5L**; `wheel`, `pip`, and `werkzeug` all report "no vulnerable package".
- Pre-fix image (committed `main`) still reports the `1 HIGH — wheel 0.45.1`, confirming Scout genuinely indexes the vendored wheel and the finding is truly resolved.
- Remaining 8M/5L are other transitive/OS packages (`filelock`, `idna`, `marshmallow`, `requests`, `flask`, `busybox`, `util-linux`, `zlib`, `xz`) — out of scope.

## Checklist

- [x] Change verified locally (build + tests + Scout scan)
- [x] No app/runtime behavior change (final image runs from `/opt/venv`; pip/setuptools are build tooling only)
- [na] Migrations
- [na] Docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)