### PR TITLE
ci: attach SBOM + SLSA provenance attestations to the Docker Hub image

### DIFF
--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -233,20 +233,14 @@ success "Snowflake registry login OK"
 
 info "Building Docker image..."
 
-# SBOM + SLSA provenance attestations (attached on the Docker Hub push, step 6)
-# require the docker-container buildx driver — the default docker driver can't
-# emit the OCI image index that carries attestation manifests. Create the
-# builder once here; both the --load build below and the --push in step 6 reuse
-# it. Tolerate a pre-existing builder from an earlier run on the same host.
+# Attestations need the docker-container driver (the default driver can't emit
+# the OCI index that carries them). Create once; reused by both builds below.
 docker buildx create --use --name sna-builder --driver docker-container 2>/dev/null \
   || docker buildx use sna-builder
 docker buildx inspect --bootstrap
 
-# Pass 1 of 2: --load a plain single-manifest image into the local daemon. This
-# copy is used for the version check (step 5) and the Snowflake SPCS push
-# (step 7) — SPCS / `snow app run` require a single-platform manifest and reject
-# the OCI image index that attestations produce. Attestations are added only on
-# the Docker Hub push (step 6), the image Docker Scout scans.
+# Pass 1: --load a single-manifest image into the daemon for the version check
+# (step 5) and the Snowflake push (step 7) — SPCS rejects the attestation index.
 docker buildx build \
   --platform linux/amd64 \
   --build-arg "code_version=${CODE_VERSION}" \
@@ -278,13 +272,10 @@ if [[ "$SKIP_DOCKER_HUB_PUSH" == "true" ]]; then
   info "Skipping Docker Hub push (--skip-docker-hub-push)"
 elif prompt_gate "Push ${DOCKER_HUB_IMAGE}:${CODE_VERSION} to Docker Hub"; then
   info "Pushing to Docker Hub with SBOM + SLSA provenance attestations..."
-  # Pass 2 of 2: re-run the build straight to Docker Hub with attestations
-  # attached — the image Docker Scout reads to clear its "missing supply chain
-  # attestation(s)" warning. --load and --push are mutually exclusive when
-  # attestations are involved, so this is a separate pass from step 4; the
-  # BuildKit cache makes it only SBOM/provenance-generation work, not a rebuild.
-  # provenance=mode=max is safe here: the only build args are public version
-  # metadata (code_version, build_number) and there are no --secret mounts.
+  # Pass 2: push to Docker Hub with attestations (the image Scout scans).
+  # Separate pass because --load and --push can't be combined with attestations;
+  # the build cache makes it cheap. mode=max is safe — build args are public
+  # version metadata, no --secret mounts.
   docker buildx build \
     --platform linux/amd64 \
     --build-arg "code_version=${CODE_VERSION}" \

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -233,13 +233,28 @@ success "Snowflake registry login OK"
 
 info "Building Docker image..."
 
-DOCKER_BUILDKIT=1 docker build \
+# SBOM + SLSA provenance attestations (attached on the Docker Hub push, step 6)
+# require the docker-container buildx driver — the default docker driver can't
+# emit the OCI image index that carries attestation manifests. Create the
+# builder once here; both the --load build below and the --push in step 6 reuse
+# it. Tolerate a pre-existing builder from an earlier run on the same host.
+docker buildx create --use --name sna-builder --driver docker-container 2>/dev/null \
+  || docker buildx use sna-builder
+docker buildx inspect --bootstrap
+
+# Pass 1 of 2: --load a plain single-manifest image into the local daemon. This
+# copy is used for the version check (step 5) and the Snowflake SPCS push
+# (step 7) — SPCS / `snow app run` require a single-platform manifest and reject
+# the OCI image index that attestations produce. Attestations are added only on
+# the Docker Hub push (step 6), the image Docker Scout scans.
+docker buildx build \
   --platform linux/amd64 \
   --build-arg "code_version=${CODE_VERSION}" \
   --build-arg "build_number=${BUILD_NUMBER}" \
   -t "${DOCKER_HUB_IMAGE}:latest" \
   -t "${DOCKER_HUB_IMAGE}:${CODE_VERSION}" \
   -f service/Dockerfile \
+  --load \
   service/
 
 success "Docker build complete"
@@ -257,15 +272,31 @@ else
   die "Version mismatch! Expected '${EXPECTED_VERSION}', got '${IMAGE_VERSION}'"
 fi
 
-# ── 6. Push to Docker Hub ───────────────────────────────────────────────────
+# ── 6. Push to Docker Hub (with SBOM + SLSA provenance attestations) ─────────
 
 if [[ "$SKIP_DOCKER_HUB_PUSH" == "true" ]]; then
   info "Skipping Docker Hub push (--skip-docker-hub-push)"
 elif prompt_gate "Push ${DOCKER_HUB_IMAGE}:${CODE_VERSION} to Docker Hub"; then
-  info "Pushing to Docker Hub..."
-  docker push "${DOCKER_HUB_IMAGE}:latest"
-  docker push "${DOCKER_HUB_IMAGE}:${CODE_VERSION}"
-  success "Pushed to Docker Hub"
+  info "Pushing to Docker Hub with SBOM + SLSA provenance attestations..."
+  # Pass 2 of 2: re-run the build straight to Docker Hub with attestations
+  # attached — the image Docker Scout reads to clear its "missing supply chain
+  # attestation(s)" warning. --load and --push are mutually exclusive when
+  # attestations are involved, so this is a separate pass from step 4; the
+  # BuildKit cache makes it only SBOM/provenance-generation work, not a rebuild.
+  # provenance=mode=max is safe here: the only build args are public version
+  # metadata (code_version, build_number) and there are no --secret mounts.
+  docker buildx build \
+    --platform linux/amd64 \
+    --build-arg "code_version=${CODE_VERSION}" \
+    --build-arg "build_number=${BUILD_NUMBER}" \
+    -t "${DOCKER_HUB_IMAGE}:latest" \
+    -t "${DOCKER_HUB_IMAGE}:${CODE_VERSION}" \
+    -f service/Dockerfile \
+    --sbom=true \
+    --provenance=mode=max \
+    --push \
+    service/
+  success "Pushed to Docker Hub with attestations"
 fi
 
 # ── 7. Tag and push to Snowflake image registry ─────────────────────────────


### PR DESCRIPTION
## Problem

Docker Scout gives the published SNA agent image a **"C" health score**, driven by a **"Missing supply chain attestation(s)"** warning (all other checks pass). Scout scans the Docker Hub image (`montecarlodata/prerelease-sna-agent` on dev, `sna-agent` on prod).

## Fix

Same approach apollo-agent shipped in #307: build the Docker Hub image with BuildKit **SBOM (SPDX)** + **SLSA provenance (mode=max)** attestations attached.

`.circleci/deploy.sh` now builds in **two passes** — mirroring apollo's handling of its attestation-incompatible Lambda/ECR target:

| Pass | Output | Purpose |
|---|---|---|
| **1** (`--load`) | plain single-manifest image → local daemon | version check (step 5) + **Snowflake SPCS push** (step 7) |
| **2** (`--push`) | OCI index with `--sbom=true --provenance=mode=max` → Docker Hub | the image **Scout scans** |

**Why two passes:** `--load` and `--push` are mutually exclusive when attestations are involved (the daemon can't load an OCI image index). BuildKit cache makes pass 2 only attestation-generation work (~seconds), not a rebuild.

**Why Snowflake stays single-manifest:** SPCS / `snow app run` require a single-platform manifest and reject the OCI image index that attestations produce (same constraint AWS Lambda has). The Snowflake push is unchanged and attestation-free — and attestations aren't relevant to SPCS anyway. Only Docker Hub needs them for the Scout score.

Attestations require the `docker-container` buildx driver (the default docker driver can't emit the OCI index), so a builder is created once up front. `provenance=mode=max` is safe here: the only build args are public version metadata (`code_version`, `build_number`) and there are no `--secret` mounts.

## Verification

Built the `final` stage locally with `--sbom=true --provenance=mode=max` to an OCI archive; the attestation manifest carries **both** predicates Scout needs:
- `https://spdx.dev/Document` (SBOM)
- `https://slsa.dev/provenance/v1` (SLSA provenance)

Full end-to-end (attestations landing on the Docker Hub image + Scout score) will confirm on the first `deploy-dev` run after merge. Verify the published attestations with:
```
docker buildx imagetools inspect montecarlodata/prerelease-sna-agent:<ver> \
  --format '{{json .SBOM.SPDX}}' | jq '{name, packages: (.packages | length)}'
```

## Checklist

- [x] Change verified locally (attestation manifest predicates confirmed)
- [x] Snowflake SPCS push path unchanged (single-manifest, no deploy risk)
- [x] No Dockerfile / app changes
- [na] Migrations
- [na] Docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)