### PR TITLE
chore(security): bump click to close CVE-2026-7246

### DIFF
--- a/service/requirements-dev.txt
+++ b/service/requirements-dev.txt
@@ -10,7 +10,7 @@ build==1.3.0
     # via pip-tools
 cfgv==3.5.0
     # via pre-commit
-click==8.3.1
+click==8.4.2
     # via
     #   -c requirements.txt
     #   black

--- a/service/requirements.in
+++ b/service/requirements.in
@@ -1,4 +1,5 @@
 -c requirements-build.txt
+click>=8.3.3  # transitive (flask); pinned for CVE-2026-7246
 dataclasses-json==0.6.7
 flask==3.0.3
 flask-sse==1.0.0

--- a/service/requirements.txt
+++ b/service/requirements.txt
@@ -34,8 +34,10 @@ charset-normalizer==3.4.4
     #   -c requirements-build.txt
     #   requests
     #   snowflake-connector-python
-click==8.3.1
-    # via flask
+click==8.4.2
+    # via
+    #   -r requirements.in
+    #   flask
 cryptography==48.0.1
     # via
     #   -c requirements-build.txt


### PR DESCRIPTION
CVE-2026-7246 (HIGH) affects click <8.3.3 and is the sole fixable HIGH/CRITICAL in the 2026-07-23 #collection-agent-vuln-scans SNA report (on `latest`).

click is transitive (via flask), so it gets an explicit floor pin (>=8.3.3) in service/requirements.in. Lockfiles recompiled under Python 3.13 in a Linux container (matching the deploy target, so the sqlalchemy->greenlet platform-conditional dep is preserved). click 8.3.1 -> 8.4.2; no other transitive churn.